### PR TITLE
fix: omit `SFCOptions.script.id`

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -47,7 +47,7 @@ export interface StoreState {
 }
 
 export interface SFCOptions {
-  script?: SFCScriptCompileOptions
+  script?: Omit<SFCScriptCompileOptions, 'id'>
   style?: SFCAsyncStyleCompileOptions
   template?: SFCTemplateCompileOptions
 }


### PR DESCRIPTION
`id` will override by `filename` in `transform.ts`