### PR TITLE
feat: allow starting on a specific view

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ const store = new ReplStore({
   // initialize repl with previously serialized state
   serializedState: location.hash.slice(1),
 
-  // start on the output pane in mobile devices, defaults to false
+  // starts on the output pane (mobile only) if the URL has a showOutput query
   showOutput: query.has('showOutput'),
-  // start on the JS output tab, defaults to "preview"
+  // starts on a different tab on the output pane if the URL has a outputMode query
+  // and default to the "preview" tab
   outputMode: (query.get('outputMode') || 'preview')
 
   // specify the default URL to import Vue runtime from in the sandbox

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ const store = new ReplStore({
   // initialize repl with previously serialized state
   serializedState: location.hash.slice(1),
 
+  // start on the output pane in mobile devices, defaults to false
+  showOutput: true,
+  // start on the JS output tab, defaults to "preview"
+  outputMode: 'js',
+
   // specify the default URL to import Vue runtime from in the sandbox
   // default is the CDN link from unpkg.com with version matching Vue's version
   // from peerDependency

--- a/README.md
+++ b/README.md
@@ -22,14 +22,17 @@ import '@vue/repl/style.css'
 import { watchEffect } from 'vue'
 import { Repl, ReplStore } from '@vue/repl'
 
+// retrieve some configuration options from the URL
+const query = new URLSearchParams(location.search)
+
 const store = new ReplStore({
   // initialize repl with previously serialized state
   serializedState: location.hash.slice(1),
 
   // start on the output pane in mobile devices, defaults to false
-  showOutput: true,
+  showOutput: query.has('showOutput'),
   // start on the JS output tab, defaults to "preview"
-  outputMode: 'js',
+  outputMode: (query.get('outputMode') || 'preview')
 
   // specify the default URL to import Vue runtime from in the sandbox
   // default is the CDN link from unpkg.com with version matching Vue's version

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
-import { ref, reactive } from 'vue'
+import { ref, reactive, onMounted } from 'vue'
 
 const container = ref()
 
 // mobile only
 const showOutput = ref(false)
+
+onMounted(() => {
+  // allow starting on the output view on mobile
+  const query = new URLSearchParams(location.search)
+  if (query.has('so')) {
+    showOutput.value = true
+  }
+})
 
 const state = reactive({
   dragging: false,

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -1,18 +1,13 @@
 <script setup lang="ts">
-import { ref, reactive, onMounted } from 'vue'
+import { ref, reactive, inject } from 'vue'
+import { ReplStore } from './store'
 
 const container = ref()
 
-// mobile only
-const showOutput = ref(false)
+const store = inject('store') as ReplStore
 
-onMounted(() => {
-  // allow starting on the output view on mobile
-  const query = new URLSearchParams(location.search)
-  if (query.has('so')) {
-    showOutput.value = true
-  }
-})
+// mobile only
+const showOutput = ref(store.initialShowOutput)
 
 const state = reactive({
   dragging: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { default as Repl } from './Repl.vue'
 export { ReplStore, File } from './store'
 export type { SFCOptions, StoreState } from './store'
+export type { OutputModes } from './output/types'

--- a/src/output/Output.vue
+++ b/src/output/Output.vue
@@ -2,7 +2,7 @@
 import Preview from './Preview.vue'
 import CodeMirror from '../codemirror/CodeMirror.vue'
 import { ReplStore } from '../store'
-import { inject, ref, computed } from 'vue'
+import { inject, ref, computed, onMounted } from 'vue'
 
 const props = defineProps<{
   showCompileOutput?: boolean
@@ -17,6 +17,15 @@ const modes = computed(() =>
 
 type Modes = typeof modes.value[number]
 const mode = ref<Modes>('preview')
+
+onMounted(() => {
+  // allow changing the mode view based on a query param named "m" (to keep the URL short)
+  const query = new URLSearchParams(location.search)
+  const targetMode = query.get('m')
+  if ((modes.value as readonly (string | null)[]).includes(targetMode)) {
+    mode.value = targetMode as Modes
+  }
+})
 </script>
 
 <template>

--- a/src/output/Output.vue
+++ b/src/output/Output.vue
@@ -16,7 +16,11 @@ const modes = computed(() =>
     : (['preview'] as const)
 )
 
-const mode = ref<OutputModes>(store.initialOutputMode)
+const mode = ref<OutputModes>(
+  (modes.value as readonly string[]).includes(store.initialOutputMode)
+    ? store.initialOutputMode as OutputModes
+    : 'preview'
+)
 </script>
 
 <template>

--- a/src/output/Output.vue
+++ b/src/output/Output.vue
@@ -2,7 +2,8 @@
 import Preview from './Preview.vue'
 import CodeMirror from '../codemirror/CodeMirror.vue'
 import { ReplStore } from '../store'
-import { inject, ref, computed, onMounted } from 'vue'
+import { inject, ref, computed } from 'vue'
+import type { OutputModes } from './types'
 
 const props = defineProps<{
   showCompileOutput?: boolean
@@ -15,17 +16,7 @@ const modes = computed(() =>
     : (['preview'] as const)
 )
 
-type Modes = typeof modes.value[number]
-const mode = ref<Modes>('preview')
-
-onMounted(() => {
-  // allow changing the mode view based on a query param named "m" (to keep the URL short)
-  const query = new URLSearchParams(location.search)
-  const targetMode = query.get('m')
-  if ((modes.value as readonly (string | null)[]).includes(targetMode)) {
-    mode.value = targetMode as Modes
-  }
-})
+const mode = ref<OutputModes>(store.initialOutputMode)
 </script>
 
 <template>

--- a/src/output/types.ts
+++ b/src/output/types.ts
@@ -1,0 +1,1 @@
+export type OutputModes = 'preview' | 'js' | 'css' | 'ssr'

--- a/src/store.ts
+++ b/src/store.ts
@@ -7,6 +7,7 @@ import {
   SFCAsyncStyleCompileOptions,
   SFCTemplateCompileOptions
 } from 'vue/compiler-sfc'
+import { OutputModes } from './output/types'
 
 const defaultMainFile = 'App.vue'
 
@@ -56,15 +57,21 @@ export class ReplStore {
   state: StoreState
   compiler = defaultCompiler
   options?: SFCOptions
+  initialShowOutput: boolean
+  initialOutputMode: OutputModes
 
   private defaultVueRuntimeURL: string
   private pendingCompiler: Promise<any> | null = null
 
   constructor({
     serializedState = '',
-    defaultVueRuntimeURL = `https://unpkg.com/@vue/runtime-dom@${version}/dist/runtime-dom.esm-browser.js`
+    defaultVueRuntimeURL = `https://unpkg.com/@vue/runtime-dom@${version}/dist/runtime-dom.esm-browser.js`,
+    showOutput = false,
+    outputMode = 'preview'
   }: {
     serializedState?: string
+    showOutput?: boolean
+    outputMode?: OutputModes
     defaultVueRuntimeURL?: string
   } = {}) {
     let files: StoreState['files'] = {}
@@ -81,6 +88,8 @@ export class ReplStore {
     }
 
     this.defaultVueRuntimeURL = defaultVueRuntimeURL
+    this.initialShowOutput = showOutput
+    this.initialOutputMode = outputMode
 
     let mainFile = defaultMainFile
     if (!files[mainFile]) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -58,7 +58,7 @@ export class ReplStore {
   compiler = defaultCompiler
   options?: SFCOptions
   initialShowOutput: boolean
-  initialOutputMode: OutputModes
+  initialOutputMode: OutputModes | string
 
   private defaultVueRuntimeURL: string
   private pendingCompiler: Promise<any> | null = null
@@ -71,7 +71,8 @@ export class ReplStore {
   }: {
     serializedState?: string
     showOutput?: boolean
-    outputMode?: OutputModes
+    // loose type to allow getting from the URL without inducing a typing error
+    outputMode?: OutputModes | string
     defaultVueRuntimeURL?: string
   } = {}) {
     let files: StoreState['files'] = {}

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,3 +1,4 @@
+import { OutputModes } from 'src/output/types'
 import { createApp, h, watchEffect } from 'vue'
 import { Repl, ReplStore } from '../src'
 
@@ -5,8 +6,11 @@ import { Repl, ReplStore } from '../src'
 
 const App = {
   setup() {
+    const query = new URLSearchParams(location.search)
     const store = new ReplStore({
       serializedState: location.hash.slice(1),
+      showOutput: query.has('so'),
+      outputMode: (query.get('om') || 'preview') as OutputModes,
       defaultVueRuntimeURL: import.meta.env.PROD
         ? undefined
         : `${location.origin}/src/vue-dev-proxy`

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,4 +1,3 @@
-import { OutputModes } from 'src/output/types'
 import { createApp, h, watchEffect } from 'vue'
 import { Repl, ReplStore } from '../src'
 
@@ -10,7 +9,7 @@ const App = {
     const store = new ReplStore({
       serializedState: location.hash.slice(1),
       showOutput: query.has('so'),
-      outputMode: (query.get('om') || 'preview') as OutputModes,
+      outputMode: query.get('om') || 'preview',
       defaultVueRuntimeURL: import.meta.env.PROD
         ? undefined
         : `${location.origin}/src/vue-dev-proxy`


### PR DESCRIPTION
This allows customizing the starting output view (preview, js, CSS, etc) and the visible pane on small viewports. This is useful when embedding the repl in websites like the documentation.

Right now it allows this URL: `http://localhost:3001/?om=js&so...` to start showing the output instead of the editor and start on the js output. These parameters can be customized by the consumer library.
