### PR TITLE
fix: adding file using enter emits error

### DIFF
--- a/src/editor/FileSelector.vue
+++ b/src/editor/FileSelector.vue
@@ -27,6 +27,7 @@ function focus({ el }: VNode) {
 }
 
 function doneAddFile() {
+  if (!pending.value) return
   const filename = pendingFilename.value
 
   if (!/\.(vue|js|ts|css)$/.test(filename)) {


### PR DESCRIPTION
Use Enter key to add file, it will emits `File "Comp.vue" already exists.`.

`doneAddFile` will execute twice (`blur` and `keyup.enter`)