### PR TITLE
fix error message styling for issue#5412 on vue/core repo

### DIFF
--- a/src/Message.vue
+++ b/src/Message.vue
@@ -61,7 +61,7 @@ function formatMessage(err: string | Error): string {
 pre {
   margin: 0;
   padding: 12px 20px;
-  white-space: initial;
+  overflow: auto;
 }
 
 .dismiss {

--- a/src/Message.vue
+++ b/src/Message.vue
@@ -61,7 +61,7 @@ function formatMessage(err: string | Error): string {
 pre {
   margin: 0;
   padding: 12px 20px;
-  overflow: scroll;
+  white-space: initial;
 }
 
 .dismiss {


### PR DESCRIPTION
I have modified the error message style for the playground site as per Evan's suggestion to drop scrolling altogether.
Here is a reference to the original issue on vue/core repository: [Issue](https://github.com/vuejs/core/issues/5412)

before:
![image](https://user-images.githubusercontent.com/71051032/153751611-4c0aac34-51b7-4722-827a-69dde04404f7.png)

after
![image](https://user-images.githubusercontent.com/71051032/153751654-36cd2607-67f7-4b53-a615-eab303c440a1.png)

and for the larger error messages, it's now shown without scrolling on the desktop and still respects the pre-formatted default behavior of the pre-tag.
![image](https://user-images.githubusercontent.com/71051032/154828298-2f1a6c47-fe63-4db2-aa56-25df71d4e5c4.png)

and only show the scrolling on mobile site: 
![image](https://user-images.githubusercontent.com/71051032/154828329-8f1f8e74-4e1c-4229-a973-a79b7d2aae29.png)









