### PR TITLE
deps: update to es-module-shims@1.5.5

### DIFF
--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -250,7 +250,7 @@
 		</script>
 
 		<!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
-		<script async src="https://unpkg.com/es-module-shims@0.10.1/dist/es-module-shims.min.js"></script>
+		<script async src="https://unpkg.com/es-module-shims@1.5.5/dist/es-module-shims.wasm.js"></script>
 		<script type="importmap"><!--IMPORT_MAP--></script>
 	</head>
 	<body></body>


### PR DESCRIPTION
Fixes #32.

Update the module `es-module-shims` from [`@0.10.1 (17.13 KB)`](https://unpkg.com/es-module-shims@0.10.1/dist/es-module-shims.min.js) to [`@1.5.5 (41.51 KB)`](https://cdn.jsdelivr.net/npm/es-module-shims@1.5.5/dist/es-module-shims.wasm.js).

- es-module-shims@0.10.1:

![Screen Shot 2022-05-22 at 9 52 05 PM](https://user-images.githubusercontent.com/46559594/169696566-2657e272-af2a-46a7-9f9e-90b768829f65.png)

- es-module-shims@1.5.5:

![Screen Shot 2022-05-22 at 9 51 26 PM](https://user-images.githubusercontent.com/46559594/169696572-e020dbe7-ef79-4837-88d9-6b4cf93cfcb7.png)

This change adds another ~25 KB to the response size of the `srcdoc.html`, still browsers should benefit from the latest [es-module-shims](https://github.com/guybedford/es-module-shims)/[es-module-lexer](https://github.com/guybedford/es-module-lexer) releases.

No discernible breakage observed.

See also:
https://github.com/guybedford/es-module-shims/pull/239