### PR TITLE
feat: export Preview component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Repl } from './Repl.vue'
+export { default as Preview } from './output/Preview.vue'
 export { ReplStore, File } from './store'
 export { compileFile } from './transform'
 export type { Props as ReplProps } from './Repl.vue'


### PR DESCRIPTION
Make it possible to create a "preview only" mode without having to render the whole repl and then try to hide the unwanted parts with `display: none`