### PR TITLE
feat: support for sandbox context customization

### DIFF
--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -14,6 +14,9 @@ export interface Props {
   sfcOptions?: SFCOptions
   layout?: string
   ssr?: boolean
+  customImportStatements?: string[]
+  customAppUsageCodes?: string[]
+  customHeadTags?: string[]
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -22,7 +25,10 @@ const props = withDefaults(defineProps<Props>(), {
   showCompileOutput: true,
   showImportMap: true,
   clearConsole: true,
-  ssr: false
+  ssr: false,
+  customImportStatements: () => [],
+  customAppUsageCodes: () => [],
+  customHeadTags: () => []
 })
 
 props.store.options = props.sfcOptions
@@ -32,6 +38,9 @@ provide('store', props.store)
 provide('autoresize', props.autoResize)
 provide('import-map', toRef(props, 'showImportMap'))
 provide('clear-console', toRef(props, 'clearConsole'))
+provide('custom-import-statements', props.customImportStatements)
+provide('custom-app-usage-codes', props.customAppUsageCodes)
+provide('custom-head-tags', props.customHeadTags)
 </script>
 
 <template>

--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -14,9 +14,14 @@ export interface Props {
   sfcOptions?: SFCOptions
   layout?: string
   ssr?: boolean
-  customImportStatements?: string[]
-  customAppUsageCodes?: string[]
-  customHeadTags?: string[]
+  previewOptions?: {
+    headHTML?: string
+    bodyHTML?: string
+    customCode?: {
+      importCode?: string
+      useCode?: string
+    }
+  }
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -26,9 +31,14 @@ const props = withDefaults(defineProps<Props>(), {
   showImportMap: true,
   clearConsole: true,
   ssr: false,
-  customImportStatements: () => [],
-  customAppUsageCodes: () => [],
-  customHeadTags: () => []
+  previewOptions: () => ({
+    headHTML: '',
+    bodyHTML: '',
+    customCode: {
+      importCode: '',
+      useCode: '',
+    },
+  }),
 })
 
 props.store.options = props.sfcOptions
@@ -38,9 +48,7 @@ provide('store', props.store)
 provide('autoresize', props.autoResize)
 provide('import-map', toRef(props, 'showImportMap'))
 provide('clear-console', toRef(props, 'clearConsole'))
-provide('custom-import-statements', props.customImportStatements)
-provide('custom-app-usage-codes', props.customAppUsageCodes)
-provide('custom-head-tags', props.customHeadTags)
+provide('preview-options', props.previewOptions)
 </script>
 
 <template>

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -172,7 +172,7 @@ async function updatePreview() {
     if (parseInt(minor, 10) < 2 || parseInt(patch, 10) < 27) {
       alert(
         `The selected version of Vue (${store.vueVersion}) does not support in-browser SSR.` +
-          ` Rendering in client mode instead.`
+        ` Rendering in client mode instead.`
       )
       isSSR = false
     }
@@ -198,9 +198,9 @@ async function updatePreview() {
          app.config.unwrapInjectedRef = true
          app.config.warnHandler = () => {}
          window.__ssr_promise__ = _renderToString(app).then(html => {
-           document.body.innerHTML = '<div id="app">' + html + '</div> + \`${
+           document.body.innerHTML = '<div id="app">' + html + '</div>' + \`${
              previewOptions?.bodyHTML || ''
-           }\`'
+           }\`
          }).catch(err => {
            console.error("SSR Error", err)
          })

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -19,6 +19,11 @@ const props = defineProps<{ show: boolean; ssr: boolean }>()
 
 const store = inject('store') as Store
 const clearConsole = inject('clear-console') as Ref<boolean>
+
+const customImportStatements = inject('custom-import-statements') as string[]
+const customAppUsageCodes = inject('custom-app-usage-codes') as string[]
+const customHeadTags = inject('custom-head-tags') as string[]
+
 const container = ref()
 const runtimeError = ref()
 const runtimeWarning = ref()
@@ -88,7 +93,7 @@ function createSandbox() {
   const sandboxSrc = srcdoc.replace(
     /<!--IMPORT_MAP-->/,
     JSON.stringify(importMap)
-  )
+  ).replace(/<!-- CUSTOM-HEAD-TAGS -->/, customHeadTags.join('\n'))
   sandbox.srcdoc = sandboxSrc
   container.value.appendChild(sandbox)
 
@@ -218,12 +223,14 @@ async function updatePreview() {
         `import { ${
           isSSR ? `createSSRApp` : `createApp`
         } as _createApp } from "vue"
+        ${customImportStatements.join('\n')}
         const _mount = () => {
           const AppComponent = __modules__["${mainFile}"].default
           AppComponent.name = 'Repl'
           const app = window.__app__ = _createApp(AppComponent)
           app.config.unwrapInjectedRef = true
           app.config.errorHandler = e => console.error(e)
+          ${customAppUsageCodes.join('\n')}
           app.mount('#app')
         }
         if (window.__ssr_promise__) {

--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -7,6 +7,7 @@
 				Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 			}
 		</style>
+		<!-- CUSTOM-HEAD-TAGS -->
 		<style id="__sfc-styles"></style>
 		<script>
 			(() => {

--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -7,7 +7,7 @@
 				Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
 			}
 		</style>
-		<!-- CUSTOM-HEAD-TAGS -->
+		<!-- PREVIEW-OPTIONS-HEAD-HTML -->
 		<style id="__sfc-styles"></style>
 		<script>
 			(() => {

--- a/test/main.ts
+++ b/test/main.ts
@@ -17,13 +17,6 @@ const App = {
         : `${location.origin}/src/vue-server-renderer-dev-proxy`
     })
 
-    store.setImportMap({
-      imports: {
-        "casual-ui-vue":
-          "https://unpkg.com/casual-ui-vue/dist/casual-ui-vue.es.js",
-      },
-    });
-
     watchEffect(() => history.replaceState({}, '', store.serialize()))
 
     // setTimeout(() => {
@@ -45,22 +38,15 @@ const App = {
       h(Repl, {
         store,
         // layout: 'vertical',
+        ssr: true,
         sfcOptions: {
           script: {
             // inlineTemplate: false
-          },
-        },
-        previewOptions: {
-          headHTML:
-            '<link rel="stylesheet" href="https://unpkg.com/casual-ui-vue/dist/style.css">',
-          customCode: {
-            importCode: `import CUI from 'casual-ui-vue'`,
-            useCode: 'app.use(CUI)'
           }
-        },
+        }
         // showCompileOutput: false,
         // showImportMap: false
-      });
+      })
   }
 }
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -17,6 +17,13 @@ const App = {
         : `${location.origin}/src/vue-server-renderer-dev-proxy`
     })
 
+    store.setImportMap({
+      imports: {
+        "casual-ui-vue":
+          "https://unpkg.com/casual-ui-vue/dist/casual-ui-vue.es.js",
+      },
+    });
+
     watchEffect(() => history.replaceState({}, '', store.serialize()))
 
     // setTimeout(() => {
@@ -38,15 +45,22 @@ const App = {
       h(Repl, {
         store,
         // layout: 'vertical',
-        ssr: true,
         sfcOptions: {
           script: {
             // inlineTemplate: false
+          },
+        },
+        previewOptions: {
+          headHTML:
+            '<link rel="stylesheet" href="https://unpkg.com/casual-ui-vue/dist/style.css">',
+          customCode: {
+            importCode: `import CUI from 'casual-ui-vue'`,
+            useCode: 'app.use(CUI)'
           }
-        }
+        },
         // showCompileOutput: false,
         // showImportMap: false
-      })
+      });
   }
 }
 

--- a/test/main.ts
+++ b/test/main.ts
@@ -17,12 +17,12 @@ const App = {
         : `${location.origin}/src/vue-server-renderer-dev-proxy`
     })
 
-    store.setImportMap({
-      imports: {
-        "casual-ui-vue":
-          "https://unpkg.com/casual-ui-vue/dist/casual-ui-vue.es.js",
-      },
-    });
+    // store.setImportMap({
+    //   imports: {
+    //     "casual-ui-vue":
+    //       "https://unpkg.com/casual-ui-vue/dist/casual-ui-vue.es.js",
+    //   },
+    // });
 
     watchEffect(() => history.replaceState({}, '', store.serialize()))
 
@@ -50,14 +50,14 @@ const App = {
             // inlineTemplate: false
           },
         },
-        previewOptions: {
-          headHTML:
-            '<link rel="stylesheet" href="https://unpkg.com/casual-ui-vue/dist/style.css">',
-          customCode: {
-            importCode: `import CUI from 'casual-ui-vue'`,
-            useCode: 'app.use(CUI)'
-          }
-        },
+        // previewOptions: {
+        //   headHTML:
+        //     '<link rel="stylesheet" href="https://unpkg.com/casual-ui-vue/dist/style.css">',
+        //   customCode: {
+        //     importCode: `import CUI from 'casual-ui-vue'`,
+        //     useCode: 'app.use(CUI)'
+        //   }
+        // },
         // showCompileOutput: false,
         // showImportMap: false
       });

--- a/test/main.ts
+++ b/test/main.ts
@@ -17,12 +17,12 @@ const App = {
         : `${location.origin}/src/vue-server-renderer-dev-proxy`
     })
 
-    // store.setImportMap({
-    //   imports: {
-    //     "casual-ui-vue":
-    //       "https://unpkg.com/casual-ui-vue/dist/casual-ui-vue.es.js",
-    //   },
-    // });
+    store.setImportMap({
+      imports: {
+        "casual-ui-vue":
+          "https://unpkg.com/casual-ui-vue/dist/casual-ui-vue.es.js",
+      },
+    });
 
     watchEffect(() => history.replaceState({}, '', store.serialize()))
 
@@ -50,14 +50,14 @@ const App = {
             // inlineTemplate: false
           },
         },
-        // previewOptions: {
-        //   headHTML:
-        //     '<link rel="stylesheet" href="https://unpkg.com/casual-ui-vue/dist/style.css">',
-        //   customCode: {
-        //     importCode: `import CUI from 'casual-ui-vue'`,
-        //     useCode: 'app.use(CUI)'
-        //   }
-        // },
+        previewOptions: {
+          headHTML:
+            '<link rel="stylesheet" href="https://unpkg.com/casual-ui-vue/dist/style.css">',
+          customCode: {
+            importCode: `import CUI from 'casual-ui-vue'`,
+            useCode: 'app.use(CUI)'
+          }
+        },
         // showCompileOutput: false,
         // showImportMap: false
       });


### PR DESCRIPTION
### Support for customize some sandbox features

* Support customize sandbox head tags, such as `<link ref="stylesheet" href="custom/css/file">`
* Support customize sandbox app import code, such as `import SomePlugin/GlobalComponent from 'customLib'`
* Support customize sandbox app usage code, such as `app.use(SomePlugin)`, `app.component('CompName', GlobalComponent)`

Example for global use [ElementPlus](https://github.com/element-plus/element-plus)

```vue
<script setup>
import { Repl, ReplStore } from '@vue/repl'

const store = new ReplStore()

store.setImportMap({
  imports: {
    'element-plus': 'https://unpkg.com/element-plus@2.2.5/es/index.mjs'
  }
})

const customImportStatements = [`import ElementPlus from 'element-plus'`]
const customAppUsageCodes = [`app.use(ElementPlus)`]
const customHeadTags = [
  `<link ref="stylesheet" href="https://unpkg.com/element-plus@2.2.5/dist/index.css">`
]
</script>
<template>
  <Repl 
    v-bind="{ 
      customImportStatements, 
      customAppUsageCodes, 
      customHeadTags,
      store
    }"
  />
</template>
```

Then in the repl editor, you can use any ElementPlus Components

```vue
<template>
  <el-button>
   A Button
  </el-button>
</template>
```

This PR can possibly solve issue (#41)