### PR TITLE
feat: support more TS syntaxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/vuejs/repl#readme",
   "devDependencies": {
-    "@babel/types": "^7.15.6",
+    "@babel/types": "^7.20.7",
     "@microsoft/api-extractor": "^7.19.2",
     "@types/codemirror": "^5.60.2",
     "@types/node": "^16.11.12",
@@ -43,8 +43,8 @@
     "fflate": "^0.7.3",
     "hash-sum": "^2.0.0",
     "rimraf": "^3.0.2",
-    "sucrase": "^3.20.1",
-    "typescript": "^4.5.4",
+    "sucrase": "^3.29.0",
+    "typescript": "^4.9.5",
     "vite": "^3.1.0",
     "vue": "^3.2.39",
     "vue-tsc": "^0.40.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
-  '@babel/types': ^7.15.6
+  '@babel/types': ^7.20.7
   '@microsoft/api-extractor': ^7.19.2
   '@types/codemirror': ^5.60.2
   '@types/node': ^16.11.12
@@ -10,14 +10,14 @@ specifiers:
   fflate: ^0.7.3
   hash-sum: ^2.0.0
   rimraf: ^3.0.2
-  sucrase: ^3.20.1
-  typescript: ^4.5.4
+  sucrase: ^3.29.0
+  typescript: ^4.9.5
   vite: ^3.1.0
   vue: ^3.2.39
   vue-tsc: ^0.40.13
 
 devDependencies:
-  '@babel/types': 7.17.12
+  '@babel/types': 7.20.7
   '@microsoft/api-extractor': 7.24.0
   '@types/codemirror': 5.60.5
   '@types/node': 16.11.36
@@ -26,16 +26,21 @@ devDependencies:
   fflate: 0.7.3
   hash-sum: 2.0.0
   rimraf: 3.0.2
-  sucrase: 3.21.0
-  typescript: 4.6.4
+  sucrase: 3.29.0
+  typescript: 4.9.5
   vite: 3.1.3
   vue: 3.2.39
-  vue-tsc: 0.40.13_typescript@4.6.4
+  vue-tsc: 0.40.13_typescript@4.9.5
 
 packages:
 
-  /@babel/helper-validator-identifier/7.16.7:
-    resolution: {integrity: sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==}
+  /@babel/helper-string-parser/7.19.4:
+    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-identifier/7.19.1:
+    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -44,14 +49,15 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.17.12
+      '@babel/types': 7.20.7
     dev: true
 
-  /@babel/types/7.17.12:
-    resolution: {integrity: sha512-rH8i29wcZ6x9xjzI5ILHL/yZkbQnCERdHlogKuIb4PUr7do4iT8DPekrTbBLWTnRQm6U0GYABbTMSzijmEqlAg==}
+  /@babel/types/7.20.7:
+    resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.16.7
+      '@babel/helper-string-parser': 7.19.4
+      '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
     dev: true
 
@@ -744,7 +750,7 @@ packages:
     dev: true
 
   /object-assign/4.1.1:
-    resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -868,8 +874,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /sucrase/3.21.0:
-    resolution: {integrity: sha512-FjAhMJjDcifARI7bZej0Bi1yekjWQHoEvWIXhLPwDhC6O4iZ5PtGb86WV56riW87hzpgB13wwBKO9vKAiWu5VQ==}
+  /sucrase/3.29.0:
+    resolution: {integrity: sha512-bZPAuGA5SdFHuzqIhTAqt9fvNEo9rESqXIG3oiKdF8K4UmkQxC4KlNL3lVyAErXp+mPvUqZ5l13qx6TrDIGf3A==}
     engines: {node: '>=8'}
     hasBin: true
     dependencies:
@@ -887,7 +893,7 @@ packages:
     dev: true
 
   /thenify-all/1.6.0:
-    resolution: {integrity: sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=}
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
     dependencies:
       thenify: 3.3.1
@@ -904,7 +910,7 @@ packages:
     dev: true
 
   /to-fast-properties/2.0.0:
-    resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=}
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
     dev: true
 
@@ -914,6 +920,12 @@ packages:
 
   /typescript/4.6.4:
     resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+    dev: true
+
+  /typescript/4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
@@ -961,7 +973,7 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vue-tsc/0.40.13_typescript@4.6.4:
+  /vue-tsc/0.40.13_typescript@4.9.5:
     resolution: {integrity: sha512-xzuN3g5PnKfJcNrLv4+mAjteMd5wLm5fRhW0034OfNJZY4WhB07vhngea/XeGn7wNYt16r7syonzvW/54dcNiA==}
     hasBin: true
     peerDependencies:
@@ -969,7 +981,7 @@ packages:
     dependencies:
       '@volar/vue-language-core': 0.40.13
       '@volar/vue-typescript': 0.40.13
-      typescript: 4.6.4
+      typescript: 4.9.5
     dev: true
 
   /vue/3.2.39:


### PR DESCRIPTION
closes #28 #70

upgrade deps, since Sucrase has supported


- TS 4.5: `import { type Foo } from 'xxx'`
- TS 4.7: [Instantiation Expressions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#instantiation-expressions): `const makeHammerBox = makeBox<Hammer>;`
- TS 4.9: `satisfies` operator: `obj satisfies SomeType`

Relate https://github.com/vuejs/core/pull/7165