### PR TITLE
fix: console logging for component instance proxies

### DIFF
--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -131,13 +131,18 @@
 				['clear', 'log', 'info', 'dir', 'warn', 'error', 'table'].forEach((level) => {
 					const original = console[level];
 					console[level] = (...args) => {
-						const msg = String(args[0])
-						if (
-							msg.includes('You are running a development build of Vue') ||
-							msg.includes('You are running the esm-bundler build of Vue')
-						) {
-							return
+						const msg = args[0]
+						if (typeof msg === 'string') {
+							if (
+								msg.includes('You are running a development build of Vue') ||
+								msg.includes('You are running the esm-bundler build of Vue')
+							) {
+								return
+							}
 						}
+
+						original(...args);
+
 						const stringifiedArgs = stringify(args);
 						if (
 							previous.level === level &&
@@ -151,13 +156,9 @@
 							try {
 								parent.postMessage({ action: 'console', level, args }, '*');
 							} catch (err) {
-								parent.postMessage({ action: 'console', level, args: args.map(a => {
-									return a instanceof Error ? a.message : String(a)
-								}) }, '*');
+								parent.postMessage({ action: 'console', level, args: args.map(toString) }, '*');
 							}
 						}
-
-						original(...args);
 					}
 				});
 
@@ -239,9 +240,26 @@
 					original_trace(...args);
 				};
 
+				function toString(value) {
+					if (value instanceof Error) {
+						return value.message;
+					}
+					for (const fn of [String, v => Object.prototype.toString.call(v), v => typeof v]) {
+						try {
+							return fn(value);
+						} catch (err) {}
+					}
+				}
+
+				function isComponentProxy(value) {
+					return value && typeof value === 'object' && value.__v_skip === true && typeof value.$nextTick === 'function' && value.$ && value._;
+				}
+
 				function stringify(args) {
 					try {
-						return JSON.stringify(args);
+						return JSON.stringify(args, (key, value) => {
+							return isComponentProxy(value) ? '{component proxy}' : value;
+						});
 					} catch (error) {
 						return null;
 					}


### PR DESCRIPTION
Console logging currently fails when the logged value is a component instance proxy:

[SFC Playground Example](https://sfc.vuejs.org/#eNo9UMtuhDAM/BXLF1iJTe4IVqp67h/kklKzsMpLSdhVhfj3OrD0EClje8YzXvEjBPFcCFvs0hDnkCFRXsJNudkGHzOsEGls4KXzMMEGY/QWKmZUygEoN3iXMnz9fnoboIe1VCO5H4r15UAF5yU6qCYyxu+8TbmNySddM5O31JdS2jfVugEW6G+HRhnzhoTx91qLpzYL8ezGr5OHbTbMIJMNRmdiBNC9XbFyr1ArBMn1Tv4PYYNHyKvVQTySd3yGfZ96N5LC9kyhkFMXrHDKOaRWyjQO5XiPJHy8S/6JuLg8WxKU7PU7+leiyMIKz9C4/QELhn2b)

Those proxies cannot be passed to `String()` without throwing the error:

> TypeError: Cannot convert object to primitive value

There were a couple of places that potentially pass those proxies to `String()`. The first (line 134) could be removed and replaced by a `typeof` check. The second I have replaced with a `toString()` helper function that handles error cases more gracefully.

The `stringify` function also caused problems because it attempts to enumerate the component's properties, leading to a warning. I've tweaked that to avoid that warning.

I've also moved the call to the original log function higher up. This helps to ensure that it still happens, even if an unexpected error occurs in the other code.