### PR TITLE
feat: local JSON files

### DIFF
--- a/src/codemirror/CodeMirror.vue
+++ b/src/codemirror/CodeMirror.vue
@@ -8,7 +8,7 @@ import { debounce } from '../utils'
 import CodeMirror from './codemirror'
 
 export interface Props {
-  mode?: string
+  mode?: string | { name: string, json: boolean }
   value?: string
   readonly?: boolean
 }

--- a/src/editor/Editor.vue
+++ b/src/editor/Editor.vue
@@ -18,6 +18,8 @@ const activeMode = computed(() => {
     ? 'htmlmixed'
     : filename.endsWith('.css')
     ? 'css'
+    : filename.endsWith('.json')
+    ? { name: 'javascript', json: true }
     : 'javascript'
 })
 </script>

--- a/src/editor/FileSelector.vue
+++ b/src/editor/FileSelector.vue
@@ -48,9 +48,9 @@ function doneAddFile() {
   if (!pending.value) return
   const filename = pendingFilename.value
 
-  if (!/\.(vue|js|ts|css)$/.test(filename)) {
+  if (!/\.(vue|js|ts|css|json)$/.test(filename)) {
     store.state.errors = [
-      `Playground only supports *.vue, *.js, *.ts, *.css files.`
+      `Playground only supports *.vue, *.js, *.ts, *.css, *.json files.`
     ]
     return
   }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -45,6 +45,20 @@ export async function compileFile(
     return
   }
 
+  if (filename.endsWith('.json')) {
+    let parsed
+    try {
+      parsed = JSON.parse(code)
+    } catch (err: any) {
+      console.error(`Error parsing ${filename}`, err.message)
+      store.state.errors = [err.message]
+      return
+    }
+    compiled.js = compiled.ssr = `export default ${JSON.stringify(parsed)}`
+    store.state.errors = []
+    return
+  }
+
   if (!filename.endsWith('.vue')) {
     store.state.errors = []
     return


### PR DESCRIPTION
This PR adds support for `.json` files. It includes adding them via the UI, syntax highlighting, and importing them within other files.

This line was a compromise:

```ts
mode?: string | { name: string, json: boolean }
```

It didn't work when I tried to use the correct type from CodeMirror, because of the union. I imagine it'll be possible to do this properly once the TS improvements in 3.3 are available.