### PR TITLE
fix css attribute HMR failure

### DIFF
--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -217,7 +217,7 @@ async function updatePreview() {
         `if (window.__app__) window.__app__.unmount()\n` +
         (isSSR ? `` : `document.body.innerHTML = '<div id="app"></div>'`),
       ...modules,
-        `setTimeout(()=>document.getElementById('__sfc-styles').innerHTML = window.__css__,1)`,
+        `setTimeout(()=> document.getElementById('__sfc-styles').innerHTML = window.__css__,1)`,
     ]
 
     // if main file is a vue file, mount it.

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -217,7 +217,7 @@ async function updatePreview() {
         `if (window.__app__) window.__app__.unmount()\n` +
         (isSSR ? `` : `document.body.innerHTML = '<div id="app"></div>'`),
       ...modules,
-      `document.getElementById('__sfc-styles').innerHTML = window.__css__`
+        `setTimeout(()=>document.getElementById('__sfc-styles').innerHTML = window.__css__,1)`,
     ]
 
     // if main file is a vue file, mount it.


### PR DESCRIPTION
After adding CSS properties to it, I noticed that they didn't take effect. While modifying the `codeToEval`, I tried using `Promise.resolve().then` and `setTimeout(()=>{},0)` to execute it, but it still didn't work. However, when I adjusted the timeout to 1ms, it started working. Did it internally use `setTimeout`? Interestingly, I observed that other synchronous operations were working fine. This situation has left me confused. Nevertheless, the current changes I made are effective.

[demo](https://play.vuejs.org/#eNpNjDEOwjAMRa8SvNOItYRIbNyAJUuaWIAwdZSkFajq3XHDwmb//99b4JxSN08IPZiKr0S+onWjUiY+ZhXIl3JyMPDbQYuluB/sBYlYXTlT3BktQSO0IHIZ/SeSt9QPoSqBE8Y27ES3/GSDD89b5mmM+8DEuc8Yj1u1bp5GWli/1UU3ug==)

Reproducible steps:
1. Open the demo.
2. Delete the style tag.
3. Restore the style tag.


https://github.com/vuejs/repl/assets/55641773/2ca91553-474a-4929-85c0-c7ea8e4897c8

