### PR TITLE
feat: support to keep selection and cursor position

### DIFF
--- a/src/monaco/Monaco.vue
+++ b/src/monaco/Monaco.vue
@@ -105,26 +105,26 @@ onMounted(async () => {
   editor.value = editorInstance
 
   // Support for semantic highlighting
-  const t = (editorInstance as any)._themeService._theme;
+  const t = (editorInstance as any)._themeService._theme
   t.getTokenStyleMetadata = (
     type: string,
     modifiers: string[],
     _language: string
   ) => {
-    const _readonly = modifiers.includes('readonly');
+    const _readonly = modifiers.includes('readonly')
     switch (type) {
       case 'function':
       case 'method':
-        return { foreground: 12 };
+        return { foreground: 12 }
       case 'class':
-        return { foreground: 11 };
+        return { foreground: 11 }
       case 'variable':
       case 'property':
-        return { foreground: _readonly ? 21 : 9 };
+        return { foreground: _readonly ? 21 : 9 }
       default:
-        return { foreground: 0 };
+        return { foreground: 0 }
     }
-  };
+  }
 
   if (props.readonly) {
     watch(
@@ -147,6 +147,11 @@ onMounted(async () => {
           file.code
         )
         editorInstance.setModel(model)
+
+        if (file.selection) {
+          editorInstance.setSelection(file.selection)
+          editorInstance.focus()
+        }
       },
       { immediate: true }
     )
@@ -160,6 +165,14 @@ onMounted(async () => {
 
   editorInstance.onDidChangeModelContent(() => {
     emits('change', editorInstance.getValue())
+  })
+
+  editorInstance.onDidChangeCursorSelection(e => {
+    const selection = e.selection
+    const file = store.state.files[props.filename]
+    if (file) {
+      file.selection = selection
+    }
   })
 })
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -8,6 +8,7 @@ import {
   SFCTemplateCompileOptions
 } from 'vue/compiler-sfc'
 import { OutputModes } from './output/types'
+import { Selection } from 'monaco-editor-core'
 
 const defaultMainFile = 'App.vue'
 
@@ -35,6 +36,7 @@ export class File {
     css: '',
     ssr: ''
   }
+  selection: Selection | null = null
 
   constructor(filename: string, code = '', hidden = false) {
     this.filename = filename


### PR DESCRIPTION
## Current issue

When switching between tabs, the cursor will be lost, and you need to re-click the file content to continue editing.

## Changes

This PR is able to save its cursor and selection when switching files, no extra mouse clicks required.

## Screenshots

before:

https://github.com/vuejs/repl/assets/15389209/34388f92-0632-43a5-a442-1ec8d7a2c9d3


after:

https://github.com/vuejs/repl/assets/15389209/811180bb-298f-49bd-9b28-839dd680ac3f

