### PR TITLE
feat: add `reload` function

### DIFF
--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -71,6 +71,18 @@ provide('autoresize', props.autoResize)
 provide('import-map', toRef(props, 'showImportMap'))
 provide('clear-console', toRef(props, 'clearConsole'))
 provide('preview-options', props.previewOptions)
+
+/**
+ * Reload the preview iframe
+ */
+function reload() {
+  const sandbox = document.querySelector('iframe[sandbox]') as HTMLIFrameElement
+  if (sandbox) {
+    sandbox.contentWindow?.location.reload()
+  }
+}
+
+defineExpose({ reload })
 </script>
 
 <template>

--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -2,7 +2,7 @@
 import SplitPane from './SplitPane.vue'
 import Output from './output/Output.vue'
 import { Store, ReplStore, SFCOptions } from './store'
-import { provide, toRef } from 'vue'
+import { provide, ref, toRef } from 'vue'
 import type { EditorComponentType } from './editor/types'
 import EditorContainer from './editor/EditorContainer.vue'
 
@@ -47,6 +47,7 @@ if (!props.editor) {
   throw new Error('The "editor" prop is now required.')
 }
 
+const outputRef = ref<InstanceType<typeof Output>>()
 const { store } = props
 const sfcOptions = (store.options = props.sfcOptions || {})
 if (!sfcOptions.script) {
@@ -76,10 +77,7 @@ provide('preview-options', props.previewOptions)
  * Reload the preview iframe
  */
 function reload() {
-  const sandbox = document.querySelector('iframe[sandbox]') as HTMLIFrameElement
-  if (sandbox) {
-    sandbox.contentWindow?.location.reload()
-  }
+  outputRef.value?.reload()
 }
 
 defineExpose({ reload })
@@ -93,6 +91,7 @@ defineExpose({ reload })
       </template>
       <template #right>
         <Output
+          ref="outputRef"
           :editorComponent="editor"
           :showCompileOutput="props.showCompileOutput"
           :ssr="!!props.ssr"

--- a/src/output/Output.vue
+++ b/src/output/Output.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
 }>()
 
 const store = inject('store') as Store
+const previewRef = ref<InstanceType<typeof Preview>>()
 const modes = computed(() =>
   props.showCompileOutput
     ? (['preview', 'js', 'css', 'ssr'] as const)
@@ -23,6 +24,12 @@ const mode = ref<OutputModes>(
     ? (store.initialOutputMode as OutputModes)
     : 'preview'
 )
+
+function reload() {
+  previewRef.value?.reload()
+}
+
+defineExpose({ reload })
 </script>
 
 <template>
@@ -37,7 +44,7 @@ const mode = ref<OutputModes>(
   </div>
 
   <div class="output-container">
-    <Preview :show="mode === 'preview'" :ssr="ssr" />
+    <Preview ref="previewRef" :show="mode === 'preview'" :ssr="ssr" />
     <props.editorComponent
       v-if="mode !== 'preview'"
       readonly

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -264,6 +264,15 @@ async function updatePreview() {
     runtimeError.value = (e as Error).message
   }
 }
+
+/**
+ * Reload the preview iframe
+ */
+function reload() {
+  sandbox.contentWindow?.location.reload()
+}
+
+defineExpose({ reload })
 </script>
 
 <template>


### PR DESCRIPTION
I have exposed a `reload` function in Repl, which reloads the preview `iframe`. It allows you to reload the preview without refreshing the entire page.