### PR TITLE
fix(monaco): enable `fixedOverflowWidgets` option

### DIFF
--- a/src/monaco/Monaco.vue
+++ b/src/monaco/Monaco.vue
@@ -101,7 +101,8 @@ onMounted(async () => {
     inlineSuggest: {
       enabled: false
     },
-    'semanticHighlighting.enabled': true
+    'semanticHighlighting.enabled': true,
+    fixedOverflowWidgets: true
   })
   editor.value = editorInstance
 


### PR DESCRIPTION
Enable fixedOverflowWidgets to render overflowing content widgets as ‘fixed’ (defaults to false). It is very useful when the REPL is embedded.

before:
![image](https://github.com/vuejs/repl/assets/26325820/617044bd-69f9-4f14-ad03-5b3d32ab2369)

![image](https://github.com/vuejs/repl/assets/26325820/86819bc7-0080-4f94-aa97-cbec0b70a14e)

after:
![image](https://github.com/vuejs/repl/assets/26325820/832914d3-9cd6-4472-9e7b-ec973d60003c)

![image](https://github.com/vuejs/repl/assets/26325820/14f19b8b-59f3-4f85-9fe8-c1c8ae783795)

