### PR TITLE
refactor: error messages

### DIFF
--- a/src/editor/EditorContainer.vue
+++ b/src/editor/EditorContainer.vue
@@ -27,13 +27,8 @@ const onChange = debounce((code: string) => {
       :value="store.state.activeFile.code"
       :filename="store.state.activeFile.filename"
     />
-    <template v-if="editorComponent.editorType !== 'monaco'">
-      <Message
-        v-show="showMessage"
-        :err="store.state.errors[0]"
-      />
-      <MessageToggle v-model="showMessage" />
-    </template>
+    <Message v-show="showMessage" :err="store.state.errors[0]" />
+    <MessageToggle v-model="showMessage" />
   </div>
 </template>
 


### PR DESCRIPTION
- Show error messages always. `compiler-sfc` errors should be displayed, even if in Monaco editor. 
- `compileFile` will return an error list now, so that we can collect all errors when first init, and they're won't be overwritten (if there's no errors in the next file).

Example: https://play.vuejs.org/#eNo9jr0OgjAUhV/l2qU4KHE1hYTN0c2lC4ELNulf2gtL03f3ionjd07OTxFDjNd9Q3EXKk/JRIKMtEWwo187LShr0WtvXAyJoEDCBSosKTiQHJPaaz8FnwlcXqH7+o18oLUBXiHZ+STP2s+4GI/PFGJWQ9+wotrfGFczELpoR0ImAPW+9aUcdbWqlulQjY8bwX5xYUbLx9g/nqn2nxb1AxpCR1Q=

Fix:
- when first open, there's no errors.
- show errors with-in Monaco editor.