### PR TITLE
feat: memorize show error state

### DIFF
--- a/src/editor/EditorContainer.vue
+++ b/src/editor/EditorContainer.vue
@@ -2,7 +2,7 @@
 import FileSelector from './FileSelector.vue'
 import Message from '../Message.vue'
 import { debounce } from '../utils'
-import { inject, ref } from 'vue'
+import { inject, ref, watch } from 'vue'
 import { Store } from '../store'
 import MessageToggle from './MessageToggle.vue'
 import type { EditorComponentType } from './types'
@@ -12,11 +12,24 @@ const props = defineProps<{
 }>()
 
 const store = inject('store') as Store
-const showMessage = ref(true)
+const showMessage = ref(getItem())
 
 const onChange = debounce((code: string) => {
   store.state.activeFile.code = code
 }, 250)
+
+function setItem(){
+  localStorage.setItem('repl_show_error', showMessage.value ? 'true':'false')
+}
+
+function getItem(){
+  const item = localStorage.getItem('repl_show_error')
+  return !(item === 'false')
+}
+
+watch(showMessage, () => {
+  setItem()
+})
 </script>
 
 <template>

--- a/src/editor/EditorContainer.vue
+++ b/src/editor/EditorContainer.vue
@@ -20,11 +20,11 @@ const onChange = debounce((code: string) => {
   store.state.activeFile.code = code
 }, 250)
 
-function setItem(){
-  localStorage.setItem(SHOW_ERROR_KEY, showMessage.value ? 'true':'false')
+function setItem() {
+  localStorage.setItem(SHOW_ERROR_KEY, showMessage.value ? 'true' : 'false')
 }
 
-function getItem(){
+function getItem() {
   const item = localStorage.getItem(SHOW_ERROR_KEY)
   return !(item === 'false')
 }

--- a/src/editor/EditorContainer.vue
+++ b/src/editor/EditorContainer.vue
@@ -7,6 +7,8 @@ import { Store } from '../store'
 import MessageToggle from './MessageToggle.vue'
 import type { EditorComponentType } from './types'
 
+const SHOW_ERROR_KEY = 'repl_show_error'
+
 const props = defineProps<{
   editorComponent: EditorComponentType
 }>()
@@ -19,11 +21,11 @@ const onChange = debounce((code: string) => {
 }, 250)
 
 function setItem(){
-  localStorage.setItem('repl_show_error', showMessage.value ? 'true':'false')
+  localStorage.setItem(SHOW_ERROR_KEY, showMessage.value ? 'true':'false')
 }
 
 function getItem(){
-  const item = localStorage.getItem('repl_show_error')
+  const item = localStorage.getItem(SHOW_ERROR_KEY)
   return !(item === 'false')
 }
 


### PR DESCRIPTION
First of all, thank you for adding the show-error function, which is really helpful for debugging code. Secondly, this PR hopes to remember the user's choice of show-error, so as to avoid having to manually refresh every time. Click the switch.