### PR TITLE
refactor: save the code with `ctrl + s`

### DIFF
--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -9,6 +9,7 @@ import EditorContainer from './editor/EditorContainer.vue'
 export interface Props {
   theme?: 'dark' | 'light'
   editor: EditorComponentType
+  autoSave?: number
   store?: Store
   autoResize?: boolean
   showCompileOutput?: boolean
@@ -37,6 +38,7 @@ const props = withDefaults(defineProps<Props>(), {
   showTsConfig: true,
   clearConsole: true,
   ssr: false,
+  autoSave: 2000,
   previewOptions: () => ({
     headHTML: '',
     bodyHTML: '',
@@ -78,6 +80,7 @@ provide('tsconfig', toRef(props, 'showTsConfig'))
 provide('clear-console', toRef(props, 'clearConsole'))
 provide('preview-options', props.previewOptions)
 provide('theme', toRef(props, 'theme'))
+provide('autoSave', props.autoSave)
 /**
  * Reload the preview iframe
  */

--- a/src/codemirror/CodeMirror.vue
+++ b/src/codemirror/CodeMirror.vue
@@ -59,6 +59,9 @@ onMounted(() => {
     }, 5000)
   })
 
+  editor.on('blur', () => {
+    save()
+  })
   el.value.addEventListener('keydown', (e) => {
     if ((e.ctrlKey || e.metaKey) && e.which == 83) {
       e.preventDefault()

--- a/src/codemirror/CodeMirror.vue
+++ b/src/codemirror/CodeMirror.vue
@@ -20,7 +20,9 @@ const props = withDefaults(defineProps<Props>(), {
   readonly: false,
 })
 
-const emit = defineEmits<(e: 'save', value: string) => void>()
+const emit = defineEmits<{
+  save: [string]
+}>()
 
 const el = ref()
 const needAutoResize = inject('autoresize')
@@ -50,14 +52,10 @@ onMounted(() => {
     ...addonOptions,
   })
 
-  let changeTimer: NodeJS.Timeout
-  editor.on('change', (e) => {
-    clearTimeout(changeTimer) // clear previous timer
-
-    changeTimer = setTimeout(() => {
-      save()
-    }, 5000)
-  })
+  const autoSave = inject<number>('autoSave')
+  if (autoSave > 0) {
+    editor.on('change', debounce(save, autoSave))
+  }
 
   editor.on('blur', () => {
     save()

--- a/src/codemirror/CodeMirror.vue
+++ b/src/codemirror/CodeMirror.vue
@@ -20,7 +20,7 @@ const props = withDefaults(defineProps<Props>(), {
   readonly: false,
 })
 
-const emit = defineEmits<(e: 'change', value: string) => void>()
+const emit = defineEmits<(e: 'save', value: string) => void>()
 
 const el = ref()
 const needAutoResize = inject('autoresize')
@@ -36,6 +36,10 @@ onMounted(() => {
         keyMap: 'sublime',
       }
 
+  function save() {
+    emit('save', editor.getValue())
+  }
+
   const editor = CodeMirror(el.value!, {
     value: '',
     mode: props.mode,
@@ -46,8 +50,20 @@ onMounted(() => {
     ...addonOptions,
   })
 
-  editor.on('change', () => {
-    emit('change', editor.getValue())
+  let changeTimer: NodeJS.Timeout
+  editor.on('change', (e) => {
+    clearTimeout(changeTimer) // clear previous timer
+
+    changeTimer = setTimeout(() => {
+      save()
+    }, 5000)
+  })
+
+  el.value.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.which == 83) {
+      e.preventDefault()
+      save()
+    }
   })
 
   watchEffect(() => {

--- a/src/codemirror/CodeMirror.vue
+++ b/src/codemirror/CodeMirror.vue
@@ -62,8 +62,8 @@ onMounted(() => {
   editor.on('blur', () => {
     save()
   })
-  el.value.addEventListener('keydown', (e) => {
-    if ((e.ctrlKey || e.metaKey) && e.which == 83) {
+  el.value.addEventListener('keydown', (e: KeyboardEvent) => {
+    if ((e.ctrlKey || e.metaKey) && e.code === 'KeyS') {
       e.preventDefault()
       save()
     }

--- a/src/editor/CodeMirrorEditor.vue
+++ b/src/editor/CodeMirrorEditor.vue
@@ -10,8 +10,8 @@ defineOptions({
 const props = defineProps<EditorProps>()
 const emit = defineEmits<EditorEmits>()
 
-const onChange = (code: string) => {
-  emit('change', code)
+const onSave = (code: string) => {
+  emit('save', code)
 }
 
 const modes: Record<string, Props['mode']> = {
@@ -39,5 +39,10 @@ const activeMode = computed(() => {
 </script>
 
 <template>
-  <CodeMirror @change="onChange" :value="value" :mode="activeMode" />
+  <CodeMirror
+    ref="codeMirrorRef"
+    :value="value"
+    :mode="activeMode"
+    @save="onSave"
+  />
 </template>

--- a/src/editor/EditorContainer.vue
+++ b/src/editor/EditorContainer.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import FileSelector from './FileSelector.vue'
 import Message from '../Message.vue'
-import { debounce } from '../utils'
 import { inject, ref, watch } from 'vue'
 import { Store } from '../store'
 import MessageToggle from './MessageToggle.vue'
@@ -16,9 +15,9 @@ const props = defineProps<{
 const store = inject('store') as Store
 const showMessage = ref(getItem())
 
-const onChange = debounce((code: string) => {
+function onSave(code: string) {
   store.state.activeFile.code = code
-}, 250)
+}
 
 function setItem() {
   localStorage.setItem(SHOW_ERROR_KEY, showMessage.value ? 'true' : 'false')
@@ -38,7 +37,7 @@ watch(showMessage, () => {
   <FileSelector />
   <div class="editor-container">
     <props.editorComponent
-      @change="onChange"
+      @save="onSave"
       :value="store.state.activeFile.code"
       :filename="store.state.activeFile.filename"
     />

--- a/src/editor/MonacoEditor.vue
+++ b/src/editor/MonacoEditor.vue
@@ -9,14 +9,14 @@ defineOptions({
   editorType: 'monaco',
 })
 
-const onChange = (code: string) => {
-  emit('change', code)
+const onSave = (code: string) => {
+  emit('save', code)
 }
 </script>
 
 <template>
   <Monaco
-    @change="onChange"
+    @save="onSave"
     :filename="filename"
     :value="value"
     :readonly="readonly"

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -10,7 +10,7 @@ export interface EditorProps {
 }
 
 export interface EditorEmits {
-  (e: 'change', code: string): void
+  (e: 'save', code: string): void
 }
 
 export type EditorComponentType = FunctionalComponent<

--- a/src/monaco/Monaco.vue
+++ b/src/monaco/Monaco.vue
@@ -30,7 +30,7 @@ const props = withDefaults(
 )
 
 const emit = defineEmits<{
-  (e: 'change', value: string): void
+  (e: 'save', value: string): void
 }>()
 
 const containerRef = ref<HTMLDivElement>()
@@ -138,12 +138,26 @@ onMounted(async () => {
 
   await loadGrammars(monaco, editorInstance)
 
+  function save() {
+    emit('save', editorInstance.getValue())
+  }
+
   editorInstance.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
-    // ignore save event
+    save()
   })
 
-  editorInstance.onDidChangeModelContent(() => {
-    emit('change', editorInstance.getValue())
+  editorInstance.onDidBlurEditorWidget(() => {
+    save()
+  })
+
+  let changeTimer: NodeJS.Timeout
+
+  editorInstance.onDidChangeModelContent((e) => {
+    clearTimeout(changeTimer) // clear previous timer
+
+    changeTimer = setTimeout(() => {
+      save()
+    }, 5000)
   })
 
   // update theme

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,7 +1,7 @@
 import { createApp, h, watchEffect } from 'vue'
 import { Repl, ReplStore } from '../src'
 import MonacoEditor from '../src/editor/MonacoEditor.vue'
-// import CodeMirrorEditor from '../src/editor/CodeMirrorEditor.vue'
+import CodeMirrorEditor from '../src/editor/CodeMirrorEditor.vue'
 import { EditorComponentType } from '../src/editor/types'
 ;(window as any).process = { env: {} }
 
@@ -43,7 +43,7 @@ const App = {
       h(Repl, {
         store,
         theme: 'dark',
-        editor: MonacoEditor as any as EditorComponentType,
+        editor: CodeMirrorEditor as any as EditorComponentType,
         // layout: 'vertical',
         ssr: true,
         sfcOptions: {

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,7 +1,7 @@
 import { createApp, h, watchEffect } from 'vue'
 import { Repl, ReplStore } from '../src'
 import MonacoEditor from '../src/editor/MonacoEditor.vue'
-import CodeMirrorEditor from '../src/editor/CodeMirrorEditor.vue'
+// import CodeMirrorEditor from '../src/editor/CodeMirrorEditor.vue'
 import { EditorComponentType } from '../src/editor/types'
 ;(window as any).process = { env: {} }
 
@@ -43,7 +43,7 @@ const App = {
       h(Repl, {
         store,
         theme: 'dark',
-        editor: CodeMirrorEditor as any as EditorComponentType,
+        editor: MonacoEditor as any as EditorComponentType,
         // layout: 'vertical',
         ssr: true,
         sfcOptions: {


### PR DESCRIPTION
If you use the change event to save the code, every input triggers the save, I refactored it to use `ctrl+s` to save the code, and if there is no input within five seconds, the code is automatically saved.