### PR TITLE
feat: support custom display placeholder content

### DIFF
--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -21,6 +21,7 @@ export interface Props {
   previewOptions?: {
     headHTML?: string
     bodyHTML?: string
+    placeholderHTML?: string
     customCode?: {
       importCode?: string
       useCode?: string
@@ -40,6 +41,7 @@ const props = withDefaults(defineProps<Props>(), {
   previewOptions: () => ({
     headHTML: '',
     bodyHTML: '',
+    placeholderHTML: '',
     customCode: {
       importCode: '',
       useCode: '',

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -90,6 +90,10 @@ function createSandbox() {
       /<!-- PREVIEW-OPTIONS-HEAD-HTML -->/,
       previewOptions?.headHTML || ''
     )
+    .replace(
+      /<!--PREVIEW-OPTIONS-PLACEHOLDER-HTML-->/,
+      previewOptions?.placeholderHTML || ''
+    )
   sandbox.srcdoc = sandboxSrc
   container.value.appendChild(sandbox)
 

--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -365,5 +365,7 @@
       <!--IMPORT_MAP-->
     </script>
   </head>
-  <body></body>
+  <body>
+    <!--PREVIEW-OPTIONS-PLACEHOLDER-HTML-->
+  </body>
 </html>


### PR DESCRIPTION
## Background
In the environment of poor network, loading cdn script and initializing preview will be blank for a long time.

<img width="1775" alt="image" src="https://github.com/vuejs/repl/assets/12692552/230dc3ae-f549-4239-9632-7694cabacde8">

## Solution
Implement custom loading animation for the initial placeholder content of iframe

```js
() =>
      h(Repl, {
       	...
        previewOptions: {
          placeholderHTML: ` <style>
      html, body {
        width: 100%;
        height: 100%;
      }
      body, html {
        display: flex;
        align-items: center;
        justify-content: center;
      }
      .loading {
        font-size: 20px;
      }
    </style>
    <div class="loading">Loading...</div>`
        }
      })
```

<img width="1775" alt="image" src="https://github.com/vuejs/repl/assets/12692552/84a0a14a-94c1-4dfb-95c6-e12cfeab49d3">
