### PR TITLE
feat(preview): allow inject customCode in SSR render and provide context constant SSR_CLIENT for conditional execution of custom code

### DIFF
--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -23,6 +23,10 @@ export interface Props {
     headHTML?: string
     bodyHTML?: string
     placeholderHTML?: string
+    customCodeSSR?: {
+      importCode?: string
+      useCode?: string
+    },
     customCode?: {
       importCode?: string
       useCode?: string
@@ -44,6 +48,10 @@ const props = withDefaults(defineProps<Props>(), {
     headHTML: '',
     bodyHTML: '',
     placeholderHTML: '',
+    customCodeSSR: {
+      importCode: '',
+      useCode: '',
+    },
     customCode: {
       importCode: '',
       useCode: '',

--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -26,7 +26,7 @@ export interface Props {
     customCodeSSR?: {
       importCode?: string
       useCode?: string
-    },
+    }
     customCode?: {
       importCode?: string
       useCode?: string

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -13,8 +13,8 @@ import {
 import srcdoc from './srcdoc.html?raw'
 import { PreviewProxy } from './PreviewProxy'
 import { compileModulesForPreview } from './moduleCompiler'
-import { Store } from '../store'
-import { Props } from '../Repl.vue'
+import type { Store } from '../store'
+import type { Props } from '../Repl.vue'
 
 const props = defineProps<{ show: boolean; ssr: boolean }>()
 
@@ -193,6 +193,9 @@ async function updatePreview() {
         ...ssrModules,
         `import { renderToString as _renderToString } from 'vue/server-renderer'
          import { createSSRApp as _createApp } from 'vue'
+         const SSR_SERVER = true
+         const SSR_CLIENT = false
+         ${previewOptions?.customCode?.importCode || ''}
          const AppComponent = __modules__["${mainFile}"].default
          AppComponent.name = 'Repl'
          const app = _createApp(AppComponent)
@@ -200,6 +203,7 @@ async function updatePreview() {
            app.config.unwrapInjectedRef = true
          }
          app.config.warnHandler = () => {}
+         ${previewOptions?.customCode?.useCode || ''}
          window.__ssr_promise__ = _renderToString(app).then(html => {
            document.body.innerHTML = '<div id="app">' + html + '</div>' + \`${
              previewOptions?.bodyHTML || ''
@@ -240,6 +244,8 @@ async function updatePreview() {
         `import { ${
           isSSR ? `createSSRApp` : `createApp`
         } as _createApp } from "vue"
+        const SSR_SERVER = false
+        const SSR_CLIENT = ${String(isSSR)}
         ${previewOptions?.customCode?.importCode || ''}
         const _mount = () => {
           const AppComponent = __modules__["${mainFile}"].default

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -193,9 +193,7 @@ async function updatePreview() {
         ...ssrModules,
         `import { renderToString as _renderToString } from 'vue/server-renderer'
          import { createSSRApp as _createApp } from 'vue'
-         const SSR_SERVER = true
-         const SSR_CLIENT = false
-         ${previewOptions?.customCode?.importCode || ''}
+         ${previewOptions?.customCodeSSR?.importCode || ''}
          const AppComponent = __modules__["${mainFile}"].default
          AppComponent.name = 'Repl'
          const app = _createApp(AppComponent)
@@ -203,7 +201,7 @@ async function updatePreview() {
            app.config.unwrapInjectedRef = true
          }
          app.config.warnHandler = () => {}
-         ${previewOptions?.customCode?.useCode || ''}
+         ${previewOptions?.customCodeSSR?.useCode || ''}
          window.__ssr_promise__ = _renderToString(app).then(html => {
            document.body.innerHTML = '<div id="app">' + html + '</div>' + \`${
              previewOptions?.bodyHTML || ''
@@ -244,7 +242,6 @@ async function updatePreview() {
         `import { ${
           isSSR ? `createSSRApp` : `createApp`
         } as _createApp } from "vue"
-        const SSR_SERVER = false
         const SSR_CLIENT = ${String(isSSR)}
         ${previewOptions?.customCode?.importCode || ''}
         const _mount = () => {


### PR DESCRIPTION
Allow code to be imported and used in the SSR render (now it can only be added on client side).
In order to provide context about execution mode we provide SSR_CLIENT context constant:

SSR_CLIENT: true only if the code is executed client side on client takeover

SSR_CLIENT: false => SPA mode(pure client)
SSR_CLIENT: true => SSR mode on client side