### PR TITLE
feat(playground): use a height of 100dvh with fallback to original 100vh

### DIFF
--- a/index-dist.html
+++ b/index-dist.html
@@ -11,6 +11,7 @@
       }
       #app {
         height: 100vh;
+        height: 100dvh;
       }
     </style>
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       }
       #app {
         height: 100vh;
+        height: 100dvh;
       }
     </style>
 


### PR DESCRIPTION
Prevents bottom part of the playground hiding under mobile browsers bottom bar