### PR TITLE
feat(messages): place error messages in editor in front of bottom toggles

### DIFF
--- a/src/Message.vue
+++ b/src/Message.vue
@@ -70,7 +70,7 @@ pre {
   bottom: 0;
   left: 8px;
   right: 8px;
-  z-index: 10;
+  z-index: 20;
   border: 2px solid transparent;
   border-radius: 6px;
   font-family: var(--font-code);


### PR DESCRIPTION
The messages are by default below the toggles and the text can be unreadable. The message can be closed to show the toggles, but the toggles cannot be removed to see the message.