### PR TITLE
fix(monaco): dispose of language event listeners after loading files from CDN

### DIFF
--- a/src/monaco/env.ts
+++ b/src/monaco/env.ts
@@ -68,7 +68,9 @@ export function loadWasm() {
 
 export class WorkerHost {
   onFetchCdnFile(uri: string, text: string) {
-    getOrCreateModel(Uri.parse(uri), undefined, text)
+    ;(
+      getOrCreateModel(Uri.parse(uri), undefined, text) as any
+    )?._languageSelectionListener?.value?.dispose()
   }
 }
 


### PR DESCRIPTION
Monaco watches all changes to the language of the files loaded. This starts emitting warnings after lots of files are loaded. We can assume that files loaded from CDN will not change language after load.