### PR TITLE
fix(Preview): fixing incorrect styles during onMounted

### DIFF
--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -228,10 +228,8 @@ async function updatePreview() {
               previewOptions?.bodyHTML || ''
             }\``),
       ...modules,
-      `setTimeout(()=> {
-        document.querySelectorAll('style[css]').forEach(el => el.remove())
-        document.head.insertAdjacentHTML('beforeend', window.__css__.map(s => \`<style css>\${s}</style>\`).join('\\n'))
-      }, 1)`,
+      `document.querySelectorAll('style[css]').forEach(el => el.remove())
+        document.head.insertAdjacentHTML('beforeend', window.__css__.map(s => \`<style css>\${s}</style>\`).join('\\n'))`,
     ]
 
     // if main file is a vue file, mount it.


### PR DESCRIPTION
relate https://github.com/vuejs/core/issues/9847

In #88, I addressed the issue of styles being lost during hot updates by implementing asynchronous loading of styles. However, this resulted in an error in obtaining the correct styles within the onMounted hook. Since the style loading mechanism has been updated in #116, resolving the problem of style loss during hot updates, I have removed the setTimeout in this PR.





https://github.com/vuejs/repl/assets/55641773/f62731f0-3ae3-44c4-99c5-60eac65908ce

