### PR TITLE
refactor!: useStore & useVueImportMap composable

### DIFF
--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import SplitPane from './SplitPane.vue'
 import Output from './output/Output.vue'
-import { type SFCOptions, type Store, useStore } from './store'
-import { computed, provide, ref, toRef, watchEffect } from 'vue'
+import { type Store, useStore } from './store'
+import { computed, provide, ref, toRef } from 'vue'
 import { type EditorComponentType, injectKeyStore } from './types'
 import EditorContainer from './editor/EditorContainer.vue'
 
@@ -15,7 +15,6 @@ export interface Props {
   showImportMap?: boolean
   showTsConfig?: boolean
   clearConsole?: boolean
-  sfcOptions?: SFCOptions
   layout?: 'horizontal' | 'vertical'
   layoutReverse?: boolean
   ssr?: boolean
@@ -49,7 +48,6 @@ const props = withDefaults(defineProps<Props>(), {
       useCode: '',
     },
   }),
-  sfcOptions: () => ({}),
   layout: 'horizontal',
 })
 
@@ -58,22 +56,6 @@ if (!props.editor) {
 }
 
 const outputRef = ref<InstanceType<typeof Output>>()
-
-watchEffect(() => {
-  const { store } = props
-  const sfcOptions = (store.sfcOptions = props.sfcOptions || store.sfcOptions)
-  sfcOptions.script ||= {}
-  sfcOptions.script.fs = {
-    fileExists(file: string) {
-      if (file.startsWith('/')) file = file.slice(1)
-      return !!store.files[file]
-    },
-    readFile(file: string) {
-      if (file.startsWith('/')) file = file.slice(1)
-      return store.files[file].code
-    },
-  }
-})
 
 props.store.init()
 

--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import SplitPane from './SplitPane.vue'
 import Output from './output/Output.vue'
-import { ReplStore, type SFCOptions, type Store } from './store'
+import { type SFCOptions, type Store, useStore } from './store'
 import { computed, provide, ref, toRef, watchEffect } from 'vue'
-import type { EditorComponentType } from './types'
+import { type EditorComponentType, injectKeyStore } from './types'
 import EditorContainer from './editor/EditorContainer.vue'
 
 export interface Props {
@@ -32,7 +32,7 @@ export interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   theme: 'light',
-  store: () => new ReplStore(),
+  store: () => useStore(),
   autoResize: true,
   showCompileOutput: true,
   showImportMap: true,
@@ -61,16 +61,16 @@ const outputRef = ref<InstanceType<typeof Output>>()
 
 watchEffect(() => {
   const { store } = props
-  const sfcOptions = (store.options = props.sfcOptions || {})
+  const sfcOptions = (store.sfcOptions = props.sfcOptions || store.sfcOptions)
   sfcOptions.script ||= {}
   sfcOptions.script.fs = {
     fileExists(file: string) {
       if (file.startsWith('/')) file = file.slice(1)
-      return !!store.state.files[file]
+      return !!store.files[file]
     },
     readFile(file: string) {
       if (file.startsWith('/')) file = file.slice(1)
-      return store.state.files[file].code
+      return store.files[file].code
     },
   }
 })
@@ -80,7 +80,7 @@ props.store.init()
 const editorSlotName = computed(() => (props.layoutReverse ? 'right' : 'left'))
 const outputSlotName = computed(() => (props.layoutReverse ? 'left' : 'right'))
 
-provide('store', props.store)
+provide(injectKeyStore, props.store)
 provide('autoresize', props.autoResize)
 provide('import-map', toRef(props, 'showImportMap'))
 provide('tsconfig', toRef(props, 'showTsConfig'))

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, inject, reactive, ref } from 'vue'
-import type { Store } from './store'
+import { computed, inject, reactive, ref, toRef } from 'vue'
+import { injectKeyStore } from './types'
 
 const props = defineProps<{ layout?: 'horizontal' | 'vertical' }>()
 const isVertical = computed(() => props.layout === 'vertical')
@@ -8,8 +8,8 @@ const isVertical = computed(() => props.layout === 'vertical')
 const container = ref()
 
 // mobile only
-const store = inject('store') as Store
-const showOutput = ref(store.initialShowOutput)
+const store = inject(injectKeyStore)!
+const showOutput = toRef(store, 'showOutput')
 
 const state = reactive({
   dragging: false,

--- a/src/editor/EditorContainer.vue
+++ b/src/editor/EditorContainer.vue
@@ -3,9 +3,8 @@ import FileSelector from './FileSelector.vue'
 import Message from '../Message.vue'
 import { debounce } from '../utils'
 import { inject, ref, watch } from 'vue'
-import type { Store } from '../store'
 import MessageToggle from './MessageToggle.vue'
-import type { EditorComponentType } from '../types'
+import { type EditorComponentType, injectKeyStore } from '../types'
 
 const SHOW_ERROR_KEY = 'repl_show_error'
 
@@ -13,11 +12,11 @@ const props = defineProps<{
   editorComponent: EditorComponentType
 }>()
 
-const store = inject('store') as Store
+const store = inject(injectKeyStore)!
 const showMessage = ref(getItem())
 
 const onChange = debounce((code: string) => {
-  store.state.activeFile.code = code
+  store.activeFile.code = code
 }, 250)
 
 function setItem() {
@@ -38,11 +37,11 @@ watch(showMessage, () => {
   <FileSelector />
   <div class="editor-container">
     <props.editorComponent
-      :value="store.state.activeFile.code"
-      :filename="store.state.activeFile.filename"
+      :value="store.activeFile.code"
+      :filename="store.activeFile.filename"
       @change="onChange"
     />
-    <Message v-show="showMessage" :err="store.state.errors[0]" />
+    <Message v-show="showMessage" :err="store.errors[0]" />
     <MessageToggle v-model="showMessage" />
   </div>
 </template>

--- a/src/editor/FileSelector.vue
+++ b/src/editor/FileSelector.vue
@@ -150,7 +150,7 @@ function horizontalScroll(e: WheelEvent) {
 
     <div class="import-map-wrapper">
       <div
-        v-if="showTsConfig && store.state.files[tsconfigFile]"
+        v-if="showTsConfig && store.files[tsconfigFile]"
         class="file"
         :class="{ active: store.activeFile.filename === tsconfigFile }"
         @click="store.setActive(tsconfigFile)"

--- a/src/editor/FileSelector.vue
+++ b/src/editor/FileSelector.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
-import {
-  type Store,
-  importMapFile,
-  stripSrcPrefix,
-  tsconfigFile,
-} from '../store'
+import { injectKeyStore } from '../../src/types'
+import { importMapFile, stripSrcPrefix, tsconfigFile } from '../store'
 import { type Ref, type VNode, computed, inject, ref } from 'vue'
 
-const store = inject('store') as Store
+const store = inject(injectKeyStore)!
 
 /**
  * When `true`: indicates adding a new file
@@ -23,7 +19,7 @@ const pendingFilename = ref('Comp.vue')
 const showTsConfig = inject<Ref<boolean>>('tsconfig')
 const showImportMap = inject<Ref<boolean>>('import-map')
 const files = computed(() =>
-  Object.entries(store.state.files)
+  Object.entries(store.files)
     .filter(
       ([name, file]) =>
         name !== importMapFile && name !== tsconfigFile && !file.hidden,
@@ -37,7 +33,7 @@ function startAddFile() {
 
   while (true) {
     let hasConflict = false
-    for (const filename in store.state.files) {
+    for (const filename in store.files) {
       if (stripSrcPrefix(filename) === name) {
         hasConflict = true
         name = `Comp${++i}.vue`
@@ -68,18 +64,18 @@ function doneNameFile() {
   const oldFilename = pending.value === true ? '' : pending.value
 
   if (!/\.(vue|js|ts|css|json)$/.test(filename)) {
-    store.state.errors = [
+    store.errors = [
       `Playground only supports *.vue, *.js, *.ts, *.css, *.json files.`,
     ]
     return
   }
 
-  if (filename !== oldFilename && filename in store.state.files) {
-    store.state.errors = [`File "${filename}" already exists.`]
+  if (filename !== oldFilename && filename in store.files) {
+    store.errors = [`File "${filename}" already exists.`]
     return
   }
 
-  store.state.errors = []
+  store.errors = []
   cancelNameFile()
 
   if (filename === oldFilename) {
@@ -122,7 +118,7 @@ function horizontalScroll(e: WheelEvent) {
       <div
         v-if="pending !== file"
         class="file"
-        :class="{ active: store.state.activeFile.filename === file }"
+        :class="{ active: store.activeFile.filename === file }"
         @click="store.setActive(file)"
         @dblclick="i > 0 && editFileName(file)"
       >
@@ -156,7 +152,7 @@ function horizontalScroll(e: WheelEvent) {
       <div
         v-if="showTsConfig && store.state.files[tsconfigFile]"
         class="file"
-        :class="{ active: store.state.activeFile.filename === tsconfigFile }"
+        :class="{ active: store.activeFile.filename === tsconfigFile }"
         @click="store.setActive(tsconfigFile)"
       >
         <span class="label">tsconfig.json</span>
@@ -164,7 +160,7 @@ function horizontalScroll(e: WheelEvent) {
       <div
         v-if="showImportMap"
         class="file"
-        :class="{ active: store.state.activeFile.filename === importMapFile }"
+        :class="{ active: store.activeFile.filename === importMapFile }"
         @click="store.setActive(importMapFile)"
       >
         <span class="label">Import Map</span>

--- a/src/import-map.ts
+++ b/src/import-map.ts
@@ -1,0 +1,50 @@
+import { computed, version as currentVersion, ref } from 'vue'
+
+export function useVueImportMap(
+  defaults: {
+    runtimeDev?: string
+    runtimeProd?: string
+    serverRenderer?: string
+  } = {},
+) {
+  const productionMode = ref(false)
+  const vueVersion = ref<string | undefined>()
+  const importMap = computed<ImportMap>(() => {
+    const vue =
+      (!vueVersion.value &&
+        (productionMode.value ? defaults.runtimeProd : defaults.runtimeDev)) ||
+      `https://cdn.jsdelivr.net/npm/@vue/runtime-dom@${
+        vueVersion.value || currentVersion
+      }/dist/runtime-dom.esm-browser${productionMode.value ? `.prod` : ``}.js`
+
+    const serverRenderer =
+      (!vueVersion.value && defaults.serverRenderer) ||
+      `https://cdn.jsdelivr.net/npm/@vue/server-renderer@${
+        vueVersion.value || currentVersion
+      }/dist/server-renderer.esm-browser.js`
+    return {
+      imports: {
+        vue,
+        'vue/server-renderer': serverRenderer,
+      },
+    }
+  })
+
+  return {
+    productionMode,
+    vueVersion,
+    importMap,
+  }
+}
+
+export interface ImportMap {
+  imports?: Record<string, string | undefined>
+  scopes?: Record<string, Record<string, string>>
+}
+
+export function mergeImportMap(a: ImportMap, b: ImportMap): ImportMap {
+  return {
+    imports: { ...a.imports, ...b.imports },
+    scopes: { ...a.scopes, ...b.scopes },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export {
   type Store,
   type ReplStore,
 } from './store'
-export { useVueImportMap, type ImportMap } from './import-map'
+export { useVueImportMap, mergeImportMap, type ImportMap } from './import-map'
 export { compileFile } from './transform'
 export type { Props as ReplProps } from './Repl.vue'
 export type { OutputModes } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 export { default as Repl } from './Repl.vue'
 export { default as Preview } from './output/Preview.vue'
-export { ReplStore, File } from './store'
+export {
+  useStore,
+  File,
+  type SFCOptions,
+  type StoreState,
+  type Store,
+} from './store'
+export { useVueImportMap, type ImportMap } from './import-map'
 export { compileFile } from './transform'
 export type { Props as ReplProps } from './Repl.vue'
-export type { Store, StoreOptions, SFCOptions, StoreState } from './store'
 export type { OutputModes } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export {
   type SFCOptions,
   type StoreState,
   type Store,
+  type ReplStore,
 } from './store'
 export { useVueImportMap, type ImportMap } from './import-map'
 export { compileFile } from './transform'

--- a/src/monaco/Monaco.vue
+++ b/src/monaco/Monaco.vue
@@ -13,8 +13,7 @@ import {
 import * as monaco from 'monaco-editor-core'
 import { initMonaco } from './env'
 import { getOrCreateModel } from './utils'
-import type { Store } from '../store'
-import type { EditorMode } from '../types'
+import { type EditorMode, injectKeyStore } from '../types'
 
 const props = withDefaults(
   defineProps<{
@@ -37,7 +36,7 @@ const emit = defineEmits<{
 const containerRef = ref<HTMLDivElement>()
 const ready = ref(false)
 const editor = shallowRef<monaco.editor.IStandaloneCodeEditor>()
-const store = inject<Store>('store')!
+const store = inject(injectKeyStore)!
 
 initMonaco(store)
 
@@ -113,7 +112,7 @@ onMounted(async () => {
       () => props.filename,
       (_, oldFilename) => {
         if (!editorInstance) return
-        const file = store.state.files[props.filename]
+        const file = store.files[props.filename]
         if (!file) return null
         const model = getOrCreateModel(
           monaco.Uri.parse(`file:///${props.filename}`),
@@ -121,7 +120,7 @@ onMounted(async () => {
           file.code,
         )
 
-        const oldFile = oldFilename ? store.state.files[oldFilename] : null
+        const oldFile = oldFilename ? store.files[oldFilename] : null
         if (oldFile) {
           oldFile.editorViewState = editorInstance.saveViewState()
         }

--- a/src/monaco/env.ts
+++ b/src/monaco/env.ts
@@ -15,8 +15,8 @@ export function initMonaco(store: Store) {
 
   watchEffect(() => {
     // create a model for each file in the store
-    for (const filename in store.state.files) {
-      const file = store.state.files[filename]
+    for (const filename in store.files) {
+      const file = store.files[filename]
       if (editor.getModel(Uri.parse(`file:///${filename}`))) continue
       getOrCreateModel(
         Uri.parse(`file:///${filename}`),
@@ -28,7 +28,7 @@ export function initMonaco(store: Store) {
     // dispose of any models that are not in the store
     for (const model of editor.getModels()) {
       const uri = model.uri.toString()
-      if (store.state.files[uri.substring('file:///'.length)]) continue
+      if (store.files[uri.substring('file:///'.length)]) continue
       if (uri.startsWith(jsDelivrUriBase + '/')) continue
       if (uri.startsWith('inmemory://')) continue
 
@@ -46,7 +46,7 @@ export function initMonaco(store: Store) {
       const path = resource.path
       if (/^\//.test(path)) {
         const fileName = path.replace('/', '')
-        if (fileName !== store.state.activeFile.filename) {
+        if (fileName !== store.activeFile.filename) {
           store.setActive(fileName)
           return true
         }
@@ -70,7 +70,7 @@ export async function reloadLanguageTools(store: Store) {
   disposeVue?.()
 
   let dependencies: Record<string, string> = {
-    ...store.state.dependencyVersion,
+    ...store.dependencyVersion,
   }
 
   if (store.vueVersion) {
@@ -88,10 +88,10 @@ export async function reloadLanguageTools(store: Store) {
     }
   }
 
-  if (store.state.typescriptVersion) {
+  if (store.typescriptVersion) {
     dependencies = {
       ...dependencies,
-      typescript: store.state.typescriptVersion,
+      typescript: store.typescriptVersion,
     }
   }
 
@@ -106,9 +106,7 @@ export async function reloadLanguageTools(store: Store) {
   })
   const languageId = ['vue', 'javascript', 'typescript']
   const getSyncUris = () =>
-    Object.keys(store.state.files).map((filename) =>
-      Uri.parse(`file:///${filename}`),
-    )
+    Object.keys(store.files).map((filename) => Uri.parse(`file:///${filename}`))
   const { dispose: disposeMarkers } = volar.editor.activateMarkers(
     worker,
     languageId,
@@ -155,8 +153,8 @@ export function loadMonacoEnv(store: Store) {
           })
           worker.postMessage({
             event: 'init',
-            tsVersion: store.state.typescriptVersion,
-            tsLocale: store.state.typescriptLocale || store.state.locale,
+            tsVersion: store.typescriptVersion,
+            tsLocale: store.locale,
           } satisfies WorkerMessage)
         })
         await init

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -48,9 +48,6 @@ watch(
   },
 )
 
-// reset sandbox when version changes
-// watch(() => store.resetFlip, createSandbox)
-
 // reset theme
 watch(
   () => theme.value,

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -13,16 +13,16 @@ import {
 import srcdoc from './srcdoc.html?raw'
 import { PreviewProxy } from './PreviewProxy'
 import { compileModulesForPreview } from './moduleCompiler'
-import type { Store } from '../store'
 import type { Props } from '../Repl.vue'
+import { injectKeyStore } from '../../src/types'
 
 const props = defineProps<{ show: boolean; ssr: boolean }>()
 
-const store = inject('store') as Store
-const clearConsole = inject('clear-console') as Ref<boolean>
-const theme = inject('theme') as Ref<'dark' | 'light'>
+const store = inject(injectKeyStore)!
+const clearConsole = inject<Ref<boolean>>('clear-console')!
+const theme = inject<Ref<'dark' | 'light'>>('theme')!
 
-const previewOptions = inject('preview-options') as Props['previewOptions']
+const previewOptions = inject<Props['previewOptions']>('preview-options')
 
 const container = ref()
 const runtimeError = ref()
@@ -42,14 +42,14 @@ watch(
     try {
       createSandbox()
     } catch (e: any) {
-      store.state.errors = [e as Error]
+      store.errors = [e as Error]
       return
     }
   },
 )
 
 // reset sandbox when version changes
-watch(() => store.state.resetFlip, createSandbox)
+// watch(() => store.resetFlip, createSandbox)
 
 // reset theme
 watch(
@@ -90,12 +90,6 @@ function createSandbox() {
   )
 
   const importMap = store.getImportMap()
-  if (!importMap.imports) {
-    importMap.imports = {}
-  }
-  if (!importMap.imports.vue) {
-    importMap.imports.vue = store.state.vueRuntimeURL
-  }
   const sandboxSrc = srcdoc
     .replace(/<html>/, `<html class="${theme.value}">`)
     .replace(/<!--IMPORT_MAP-->/, JSON.stringify(importMap))
@@ -193,7 +187,7 @@ async function updatePreview() {
   }
 
   try {
-    const mainFile = store.state.mainFile
+    const mainFile = store.mainFile
 
     // if SSR, generate the SSR bundle and eval it to render the HTML
     if (isSSR && mainFile.endsWith('.vue')) {

--- a/src/output/moduleCompiler.ts
+++ b/src/output/moduleCompiler.ts
@@ -13,19 +13,13 @@ import type { ExportSpecifier, Identifier, Node } from '@babel/types'
 export function compileModulesForPreview(store: Store, isSSR = false) {
   const seen = new Set<File>()
   const processed: string[] = []
-  processFile(
-    store,
-    store.state.files[store.state.mainFile],
-    processed,
-    seen,
-    isSSR,
-  )
+  processFile(store, store.files[store.mainFile], processed, seen, isSSR)
 
   if (!isSSR) {
     // also add css files that are not imported
-    for (const filename in store.state.files) {
+    for (const filename in store.files) {
       if (filename.endsWith('.css')) {
-        const file = store.state.files[filename]
+        const file = store.files[filename]
         if (!seen.has(file)) {
           processed.push(
             `\nwindow.__css__.push(${JSON.stringify(file.compiled.css)})`,
@@ -96,14 +90,14 @@ function processChildFiles(
 ) {
   if (hasDynamicImport) {
     // process all files
-    for (const file of Object.values(store.state.files)) {
+    for (const file of Object.values(store.files)) {
       if (seen.has(file)) continue
       processFile(store, file, processed, seen, isSSR)
     }
   } else if (importedFiles.size > 0) {
     // crawl child imports
     for (const imported of importedFiles) {
-      processFile(store, store.state.files[imported], processed, seen, isSSR)
+      processFile(store, store.files[imported], processed, seen, isSSR)
     }
   }
 }
@@ -122,7 +116,7 @@ function processModule(store: Store, src: string, filename: string) {
   const importToIdMap = new Map<string, string>()
 
   function resolveImport(raw: string): string | undefined {
-    const files = store.state.files
+    const files = store.files
     let resolved = raw
     const file =
       files[resolved] ||

--- a/src/store.ts
+++ b/src/store.ts
@@ -94,6 +94,24 @@ export function useStore(
       }
     })
 
+    watch(
+      sfcOptions,
+      () => {
+        sfcOptions.value.script ||= {}
+        sfcOptions.value.script.fs = {
+          fileExists(file: string) {
+            if (file.startsWith('/')) file = file.slice(1)
+            return !!store.files[file]
+          },
+          readFile(file: string) {
+            if (file.startsWith('/')) file = file.slice(1)
+            return store.files[file].code
+          },
+        }
+      },
+      { immediate: true },
+    )
+
     // init tsconfig
     if (!files.value[tsconfigFile]) {
       files.value[tsconfigFile] = new File(

--- a/src/store.ts
+++ b/src/store.ts
@@ -74,6 +74,14 @@ export function useStore(
       { deep: true },
     )
 
+    watch(
+      builtinImportMap,
+      () => {
+        setImportMap(mergeImportMap(getImportMap(), builtinImportMap.value))
+      },
+      { deep: true, immediate: true },
+    )
+
     watch(vueVersion, async (version) => {
       if (version) {
         const compilerUrl = `https://cdn.jsdelivr.net/npm/@vue/compiler-sfc@${version}/dist/compiler-sfc.esm-browser.js`
@@ -85,15 +93,6 @@ export function useStore(
         console.info(`[@vue/repl] Now using default Vue version`)
       }
     })
-
-    applyBuiltinImportMap()
-    watch(
-      builtinImportMap,
-      () => {
-        setImportMap(mergeImportMap(getImportMap(), builtinImportMap.value))
-      },
-      { deep: true },
-    )
 
     // init tsconfig
     if (!files.value[tsconfigFile]) {
@@ -286,6 +285,8 @@ export function useStore(
     mainFile.value = Object.keys(files.value)[0]
   }
   activeFile ||= ref(files.value[mainFile.value])
+
+  applyBuiltinImportMap()
 
   const store: ReplStore = reactive({
     files,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
-import type { Component } from 'vue'
+import type { Component, InjectionKey } from 'vue'
+import type { Store } from './store'
 
 export type EditorMode = 'js' | 'css' | 'ssr'
 export interface EditorProps {
@@ -13,3 +14,5 @@ export interface EditorEmits {
 export type EditorComponentType = Component<EditorProps>
 
 export type OutputModes = 'preview' | EditorMode
+
+export const injectKeyStore: InjectionKey<Store> = Symbol('store')

--- a/test/main.ts
+++ b/test/main.ts
@@ -31,17 +31,17 @@ const App = {
     watchEffect(() => history.replaceState({}, '', store.serialize()))
 
     // setTimeout(() => {
-    // store.setFiles(
-    //   {
-    //     'index.html': '<h1>yo</h1>',
-    //     'main.js': 'document.body.innerHTML = "<h1>hello</h1>"',
-    //     'foo.js': 'document.body.innerHTML = "<h1>hello</h1>"',
-    //     'bar.js': 'document.body.innerHTML = "<h1>hello</h1>"',
-    //     'baz.js': 'document.body.innerHTML = "<h1>hello</h1>"'
-    //   },
-    //   'index.html'
-    // )
-    // }, 1000);
+    //   store.setFiles(
+    //     {
+    //       'src/index.html': '<h1>yo</h1>',
+    //       'src/main.js': 'document.body.innerHTML = "<h1>hello</h1>"',
+    //       'src/foo.js': 'document.body.innerHTML = "<h1>hello</h1>"',
+    //       'src/bar.js': 'document.body.innerHTML = "<h1>hello</h1>"',
+    //       'src/baz.js': 'document.body.innerHTML = "<h1>hello</h1>"',
+    //     },
+    //     'src/index.html',
+    //   )
+    // }, 1000)
 
     store.vueVersion = '3.4.1'
 


### PR DESCRIPTION
- Separate import map and store as two functions
  - `useStore`: keep most of the functionality, and refactor to composables
  - `useVueImportMap`: extract links of the Vue import map.
