### PR TITLE
fix: don't overwrite `a` tag without href 

### DIFF
--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -89,7 +89,8 @@
                   el.hasAttribute('download') ||
                   el.getAttribute('rel') === 'external' ||
                   el.target ||
-                  el.href.startsWith('javascript:')
+                  el.href.startsWith('javascript:') ||
+                  !el.href
                 )
                   return
 
@@ -102,9 +103,8 @@
                     return
                   }
                 }
-                if(el.href){
-                  window.open(el.href, '_blank')
-                }
+
+                window.open(el.href, '_blank')
               })
               send_ok()
             } catch (e) {

--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -102,8 +102,9 @@
                     return
                   }
                 }
-
-                window.open(el.href, '_blank')
+                if(el.href){
+                  window.open(el.href, '_blank')
+                }
               })
               send_ok()
             } catch (e) {


### PR DESCRIPTION
Fix the problem of opening a new tab when clicking on the a tag does not have href attribute