### PR TITLE
fix: dynamic import

### DIFF
--- a/src/output/moduleCompiler.ts
+++ b/src/output/moduleCompiler.ts
@@ -295,7 +295,7 @@ function processModule(store: Store, src: string, filename: string) {
           s.overwrite(
             arg.start!,
             arg.end!,
-            JSON.stringify(arg.value.replace(/^\.\/+/, '')),
+            JSON.stringify(arg.value.replace(/^\.\/+/, 'src/')),
           )
         }
       }


### PR DESCRIPTION
Dynamic imports were not functioning correctly because the rewritten import paths lacked the necessary "src/" prefix.

I have updated the path rewriting logic to correctly prepend "src/" to the import paths. This ensures that dynamic imports resolve correctly and function as expected.

fix: https://github.com/vuejs/repl/issues/208

[Preview](https://repl-git-fork-youxam-dynamic-import-vuejs.vercel.app/#eNqVU8tOwzAQ/JXFl7ZSkxy4RWklXgeQeAg4+pImm2Jwbct2Squq/87aIaEIqMTN+/B4Zna9Y2fGpOsWWc4KV1lhPDj0rZlzJVZGWw87sNhMocZGKDxzW1VdaKooVB720Fi9ghEBjLjiqtLKefDlAmaw4wqg6lvzXwHG4wnM5tC9NB6lWagEOqPJhKv9F2TIE+b/MXqAWjgjyy3WhEJ6xk0pHVK9yDrVpJcCjyvq8kgRQPFis5imoywXKGOWAqFM62GdrHSNcsbZgM0Z+K1BSlUvWL0t9Iazz0uXQ0+Ay3q8GNViTWii+Q7VvxalByIxOkmSYjAVcuHoEvmdDjnikM2TpFOQEXT/SqemyA40sinzjvxpxDJ9dVrREsSpEX+CExLtvfGC/OMs7+YZaqWU+v0m5rxtcdrno+Zf8q+ObMjp8GDRoV0jZ0PNl3aJxDmUr57ucEPnoUj+tpK6jxQf0WnZBo5d23mraqJ90BfZXsflEGr57K42HpXrRQWioXMf+zmjtQl+/yX9i+5pehrv0ZaSi/3K/fhFx9arm00AvkX9fjiv70PafwAhuzbZ)