### PR TITLE
fix: use vue esm bundler while running SSR

### DIFF
--- a/src/import-map.ts
+++ b/src/import-map.ts
@@ -30,10 +30,16 @@ export function useVueImportMap(
       `https://cdn.jsdelivr.net/npm/@vue/server-renderer@${
         vueVersion.value || currentVersion
       }/dist/server-renderer.esm-browser.js`
+
+    const vueEsm = `https://cdn.jsdelivr.net/npm/@vue/runtime-dom@${
+      vueVersion.value || currentVersion
+    }/dist/runtime-dom.esm-bundler.js/+esm`
+
     return {
       imports: {
         vue,
         'vue/server-renderer': serverRenderer,
+        'vue-esm': vueEsm,
       },
     }
   })

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -266,9 +266,9 @@ async function doCompileScript(
       )} */`
     }
     if (ssr) {
-      compiledScript.content = compiledScript.content.replaceAll(
-        /'vue'/g,
-        "'vue-esm'",
+      compiledScript.content = compiledScript.content.replace(
+        /(['"])vue\1/g,
+        '$1vue-esm$1',
       )
     }
     code +=

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -265,6 +265,12 @@ async function doCompileScript(
         2,
       )} */`
     }
+    if (ssr) {
+      compiledScript.content = compiledScript.content.replaceAll(
+        /'vue'/g,
+        "'vue-esm'",
+      )
+    }
     code +=
       `\n` +
       store.compiler.rewriteDefault(


### PR DESCRIPTION
[fixbug#9445](https://github.com/vuejs/core/issues/9445)

When repl performs ssr in the online environment, `import { useModel as _useModel } from 'vue'` will use the `*runtime.esm-browser.js` file, but in the dev environment it will The `*rutime-dom.esm-bundler.js` file is used, so there is no problem with the dev environment

![image](https://github.com/vuejs/core/assets/40790268/9284ebbc-f859-4e0e-9525-d4f32cc0f7e0)
![image](https://github.com/vuejs/core/assets/40790268/bfd4c928-8351-4e00-94af-8e467cd8a243)
![image](https://github.com/vuejs/core/assets/40790268/9baa57ab-a278-46b8-b59f-8eb80b53adff)

---
The processing of these two file formats for SSR is different. So ssr bug will appear in the online environment.


![image](https://github.com/vuejs/core/assets/40790268/28c8fc6b-0ffd-412e-b171-23c51e6ebd96)


