### PR TITLE
fix: refine dragging view area

### DIFF
--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -37,7 +37,7 @@ function dragMove(e: MouseEvent) {
       ? container.value.offsetHeight
       : container.value.offsetWidth
     const dp = position - startPosition
-    state.split = startSplit + ~~((dp / totalSize) * 100)
+    state.split = startSplit + Number(((dp / totalSize) * 100).toFixed(2))
   }
 }
 

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -37,7 +37,7 @@ function dragMove(e: MouseEvent) {
       ? container.value.offsetHeight
       : container.value.offsetWidth
     const dp = position - startPosition
-    state.split = startSplit + Number(((dp / totalSize) * 100).toFixed(2))
+    state.split = startSplit + +((dp / totalSize) * 100).toFixed(2)
   }
 }
 


### PR DESCRIPTION
When dragging the view area to view the responsive effect, since the width calculation percentage is now an integer, some edge case values will be skipped directly, making it difficult to meet the conditions you want to test.