### PR TITLE
feat: show view size while dragging split pane

### DIFF
--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -60,7 +60,6 @@ if (!props.editor) {
 }
 
 const outputRef = ref<InstanceType<typeof Output>>()
-const splitPaneRef = ref<InstanceType<typeof SplitPane>>()
 
 props.store.init()
 
@@ -76,12 +75,7 @@ provide('clear-console', toRef(props, 'clearConsole'))
 provide('preview-options', props.previewOptions)
 provide('theme', toRef(props, 'theme'))
 provide('preview-theme', toRef(props, 'previewTheme'))
-
-function changeSize() {
-  if (outputRef.value?.previewRef?.container) {
-    splitPaneRef.value?.changeViewSize(outputRef.value.previewRef.container)
-  }
-}
+provide('preview-ref', () => outputRef.value?.previewRef?.container)
 
 /**
  * Reload the preview iframe
@@ -95,11 +89,7 @@ defineExpose({ reload })
 
 <template>
   <div class="vue-repl">
-    <SplitPane
-      :layout="layout"
-      ref="splitPaneRef"
-      @draggingChangeSize="changeSize"
-    >
+    <SplitPane :layout="layout">
       <template #[editorSlotName]>
         <EditorContainer :editor-component="editor" />
       </template>

--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -60,6 +60,7 @@ if (!props.editor) {
 }
 
 const outputRef = ref<InstanceType<typeof Output>>()
+const splitPaneRef = ref<InstanceType<typeof SplitPane>>()
 
 props.store.init()
 
@@ -75,6 +76,13 @@ provide('clear-console', toRef(props, 'clearConsole'))
 provide('preview-options', props.previewOptions)
 provide('theme', toRef(props, 'theme'))
 provide('preview-theme', toRef(props, 'previewTheme'))
+
+function changeSize() {
+  if (outputRef.value?.previewRef?.container) {
+    splitPaneRef.value?.changeViewSize(outputRef.value.previewRef.container)
+  }
+}
+
 /**
  * Reload the preview iframe
  */
@@ -87,7 +95,11 @@ defineExpose({ reload })
 
 <template>
   <div class="vue-repl">
-    <SplitPane :layout="layout">
+    <SplitPane
+      :layout="layout"
+      ref="splitPaneRef"
+      @draggingChangeSize="changeSize"
+    >
       <template #[editorSlotName]>
         <EditorContainer :editor-component="editor" />
       </template>

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -42,7 +42,7 @@ function dragMove(e: MouseEvent) {
     const dp = position - startPosition
     state.split = startSplit + +((dp / totalSize) * 100).toFixed(2)
 
-    state.viewHeight = rightView.value.offsetHeight
+    state.viewHeight = rightView.value.offsetHeight - 38
     state.viewWidth = rightView.value.offsetWidth
   }
 }
@@ -52,7 +52,7 @@ function dragEnd() {
 }
 
 onMounted(() => {
-  state.viewHeight = rightView.value.offsetHeight
+  state.viewHeight = rightView.value.offsetHeight - 38
   state.viewWidth = rightView.value.offsetWidth
 })
 </script>

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -1,14 +1,20 @@
 <script setup lang="ts">
-import { computed, inject, reactive, ref, toRef } from 'vue'
+import {
+  type MaybeRefOrGetter,
+  computed,
+  inject,
+  reactive,
+  ref,
+  toRef,
+  toValue,
+} from 'vue'
 import { injectKeyStore } from './types'
 
-const emit = defineEmits<{
-  (e: 'draggingChangeSize'): void
-}>()
 const props = defineProps<{ layout?: 'horizontal' | 'vertical' }>()
 const isVertical = computed(() => props.layout === 'vertical')
 
 const container = ref()
+const previewRef = inject<MaybeRefOrGetter<HTMLDivElement>>('preview-ref')!
 
 // mobile only
 const store = inject(injectKeyStore)!
@@ -34,7 +40,7 @@ function dragStart(e: MouseEvent) {
   startPosition = isVertical.value ? e.pageY : e.pageX
   startSplit = boundSplit.value
 
-  emit('draggingChangeSize')
+  changeViewSize()
 }
 
 function dragMove(e: MouseEvent) {
@@ -46,7 +52,7 @@ function dragMove(e: MouseEvent) {
     const dp = position - startPosition
     state.split = startSplit + +((dp / totalSize) * 100).toFixed(2)
 
-    emit('draggingChangeSize')
+    changeViewSize()
   }
 }
 
@@ -54,7 +60,8 @@ function dragEnd() {
   state.dragging = false
 }
 
-function changeViewSize(el: HTMLElement) {
+function changeViewSize() {
+  const el = toValue(previewRef)
   state.viewHeight = el.offsetHeight
   state.viewWidth = el.offsetWidth
 }

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -14,6 +14,8 @@ const showOutput = toRef(store, 'showOutput')
 const state = reactive({
   dragging: false,
   split: 50,
+  viewHeight: 0,
+  viewWidth: 0,
 })
 
 const boundSplit = computed(() => {
@@ -38,6 +40,9 @@ function dragMove(e: MouseEvent) {
       : container.value.offsetWidth
     const dp = position - startPosition
     state.split = startSplit + +((dp / totalSize) * 100).toFixed(2)
+    const view = container.value.children[1]
+    state.viewHeight = view.offsetHeight
+    state.viewWidth = view.offsetWidth
   }
 }
 
@@ -70,6 +75,9 @@ function dragEnd() {
       class="right"
       :style="{ [isVertical ? 'height' : 'width']: 100 - boundSplit + '%' }"
     >
+      <div class="view-size" v-show="state.dragging">
+        {{ `${state.viewWidth}px x ${state.viewHeight}px` }}
+      </div>
       <slot name="right" />
     </div>
 
@@ -96,6 +104,14 @@ function dragEnd() {
 .right {
   position: relative;
   height: 100%;
+}
+.view-size {
+  position: absolute;
+  top: 40px;
+  left: 10px;
+  font-size: 12px;
+  color: var(--text-light);
+  z-index: 100;
 }
 .left {
   border-right: 1px solid var(--border);

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import { computed, inject, reactive, ref, toRef, onMounted } from 'vue'
+import { computed, inject, reactive, ref, toRef } from 'vue'
 import { injectKeyStore } from './types'
 
+const emit = defineEmits<{
+  (e: 'draggingChangeSize'): void
+}>()
 const props = defineProps<{ layout?: 'horizontal' | 'vertical' }>()
 const isVertical = computed(() => props.layout === 'vertical')
 
 const container = ref()
-const rightView = ref()
 
 // mobile only
 const store = inject(injectKeyStore)!
@@ -31,6 +33,8 @@ function dragStart(e: MouseEvent) {
   state.dragging = true
   startPosition = isVertical.value ? e.pageY : e.pageX
   startSplit = boundSplit.value
+
+  emit('draggingChangeSize')
 }
 
 function dragMove(e: MouseEvent) {
@@ -42,9 +46,7 @@ function dragMove(e: MouseEvent) {
     const dp = position - startPosition
     state.split = startSplit + +((dp / totalSize) * 100).toFixed(2)
 
-    const viewElement = rightView.value.querySelector('iframe')
-    state.viewHeight = viewElement.offsetHeight
-    state.viewWidth = viewElement.offsetWidth
+    emit('draggingChangeSize')
   }
 }
 
@@ -52,10 +54,13 @@ function dragEnd() {
   state.dragging = false
 }
 
-onMounted(() => {
-  const viewElement = rightView.value.querySelector('iframe')
-  state.viewHeight = viewElement.offsetHeight
-  state.viewWidth = viewElement.offsetWidth
+function changeViewSize(el: HTMLElement) {
+  state.viewHeight = el.offsetHeight
+  state.viewWidth = el.offsetWidth
+}
+
+defineExpose({
+  changeViewSize,
 })
 </script>
 
@@ -80,7 +85,6 @@ onMounted(() => {
       <div class="dragger" @mousedown.prevent="dragStart" />
     </div>
     <div
-      ref="rightView"
       class="right"
       :style="{ [isVertical ? 'height' : 'width']: 100 - boundSplit + '%' }"
     >

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed, inject, reactive, ref, toRef } from 'vue'
+import { computed, inject, reactive, ref, toRef, onMounted } from 'vue'
 import { injectKeyStore } from './types'
 
 const props = defineProps<{ layout?: 'horizontal' | 'vertical' }>()
 const isVertical = computed(() => props.layout === 'vertical')
 
 const container = ref()
+const rightView = ref()
 
 // mobile only
 const store = inject(injectKeyStore)!
@@ -40,15 +41,20 @@ function dragMove(e: MouseEvent) {
       : container.value.offsetWidth
     const dp = position - startPosition
     state.split = startSplit + +((dp / totalSize) * 100).toFixed(2)
-    const view = container.value.children[1]
-    state.viewHeight = view.offsetHeight
-    state.viewWidth = view.offsetWidth
+
+    state.viewHeight = rightView.value.offsetHeight
+    state.viewWidth = rightView.value.offsetWidth
   }
 }
 
 function dragEnd() {
   state.dragging = false
 }
+
+onMounted(() => {
+  state.viewHeight = rightView.value.offsetHeight
+  state.viewWidth = rightView.value.offsetWidth
+})
 </script>
 
 <template>
@@ -72,6 +78,7 @@ function dragEnd() {
       <div class="dragger" @mousedown.prevent="dragStart" />
     </div>
     <div
+      ref="rightView"
       class="right"
       :style="{ [isVertical ? 'height' : 'width']: 100 - boundSplit + '%' }"
     >

--- a/src/SplitPane.vue
+++ b/src/SplitPane.vue
@@ -42,8 +42,9 @@ function dragMove(e: MouseEvent) {
     const dp = position - startPosition
     state.split = startSplit + +((dp / totalSize) * 100).toFixed(2)
 
-    state.viewHeight = rightView.value.offsetHeight - 38
-    state.viewWidth = rightView.value.offsetWidth
+    const viewElement = rightView.value.querySelector('iframe')
+    state.viewHeight = viewElement.offsetHeight
+    state.viewWidth = viewElement.offsetWidth
   }
 }
 
@@ -52,8 +53,9 @@ function dragEnd() {
 }
 
 onMounted(() => {
-  state.viewHeight = rightView.value.offsetHeight - 38
-  state.viewWidth = rightView.value.offsetWidth
+  const viewElement = rightView.value.querySelector('iframe')
+  state.viewHeight = viewElement.offsetHeight
+  state.viewWidth = viewElement.offsetWidth
 })
 </script>
 

--- a/src/output/Output.vue
+++ b/src/output/Output.vue
@@ -37,7 +37,7 @@ function reload() {
   previewRef.value?.reload()
 }
 
-defineExpose({ reload })
+defineExpose({ reload, previewRef })
 </script>
 
 <template>

--- a/src/output/Preview.vue
+++ b/src/output/Preview.vue
@@ -286,7 +286,7 @@ function reload() {
   sandbox.contentWindow?.location.reload()
 }
 
-defineExpose({ reload })
+defineExpose({ reload, container })
 </script>
 
 <template>


### PR DESCRIPTION
When dragging a view, the size of the view area is displayed in real time, without the need to confirm through developer tools.