### PR TITLE
fix: cancel creating new file

### DIFF
--- a/src/editor/FileSelector.vue
+++ b/src/editor/FileSelector.vue
@@ -58,6 +58,10 @@ function focus({ el }: VNode) {
 
 function doneNameFile() {
   if (!pending.value) return
+  if (!pendingFilename.value) {
+    pending.value = false
+  }
+
   // add back the src prefix
   const filename = 'src/' + pendingFilename.value
   const oldFilename = pending.value === true ? '' : pending.value
@@ -66,9 +70,6 @@ function doneNameFile() {
     store.value.errors = [
       `Playground only supports *.vue, *.jsx?, *.tsx?, *.css, *.json files.`,
     ]
-    if (!pendingFilename.value) {
-      pending.value = false
-    }
     return
   }
 

--- a/src/editor/FileSelector.vue
+++ b/src/editor/FileSelector.vue
@@ -66,6 +66,7 @@ function doneNameFile() {
     store.value.errors = [
       `Playground only supports *.vue, *.jsx?, *.tsx?, *.css, *.json files.`,
     ]
+    pending.value = false
     return
   }
 

--- a/src/editor/FileSelector.vue
+++ b/src/editor/FileSelector.vue
@@ -66,7 +66,9 @@ function doneNameFile() {
     store.value.errors = [
       `Playground only supports *.vue, *.jsx?, *.tsx?, *.css, *.json files.`,
     ]
-    pending.value = false
+    if (!pendingFilename.value) {
+      pending.value = false
+    }
     return
   }
 

--- a/src/editor/FileSelector.vue
+++ b/src/editor/FileSelector.vue
@@ -60,6 +60,7 @@ function doneNameFile() {
   if (!pending.value) return
   if (!pendingFilename.value) {
     pending.value = false
+    return
   }
 
   // add back the src prefix


### PR DESCRIPTION
When the file name is empty, it looks weird after the input box loses focus.

<img width="314" alt="image" src="https://github.com/user-attachments/assets/9f870f1b-d8d4-45fd-9e13-f81edb985bde">
