### PR TITLE
feat: add core entry for node usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/codemirror-editor.js",
       "require": null
     },
+    "./store": {
+      "types": "./dist/store.d.ts",
+      "import": "./dist/store.js",
+      "require": null
+    },
     "./transform": {
       "types": "./dist/transform.d.ts",
       "import": "./dist/transform.js",

--- a/package.json
+++ b/package.json
@@ -26,14 +26,9 @@
       "import": "./dist/codemirror-editor.js",
       "require": null
     },
-    "./store": {
-      "types": "./dist/store.d.ts",
-      "import": "./dist/store.js",
-      "require": null
-    },
-    "./transform": {
-      "types": "./dist/transform.d.ts",
-      "import": "./dist/transform.js",
+    "./core": {
+      "types": "./dist/core.d.ts",
+      "import": "./dist/core.js",
       "require": null
     },
     "./package.json": "./package.json",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
       "import": "./dist/codemirror-editor.js",
       "require": null
     },
+    "./transform": {
+      "types": "./dist/transform.d.ts",
+      "import": "./dist/transform.js",
+      "require": null
+    },
     "./package.json": "./package.json",
     "./style.css": "./dist/vue-repl.css",
     "./dist/style.css": "./dist/vue-repl.css"

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,7 +8,4 @@ export {
 } from './store'
 export { useVueImportMap, mergeImportMap, type ImportMap } from './import-map'
 export { compileFile } from './transform'
-export type { Props as ReplProps } from './Repl.vue'
-export type { SandboxProps } from './output/Sandbox.vue'
-export type { OutputModes } from './types'
 export { version as languageToolsVersion } from '@vue/language-service/package.json'

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,14 @@
+export {
+  useStore,
+  File,
+  type SFCOptions,
+  type StoreState,
+  type Store,
+  type ReplStore,
+} from './store'
+export { useVueImportMap, mergeImportMap, type ImportMap } from './import-map'
+export { compileFile } from './transform'
+export type { Props as ReplProps } from './Repl.vue'
+export type { SandboxProps } from './output/Sandbox.vue'
+export type { OutputModes } from './types'
+export { version as languageToolsVersion } from '@vue/language-service/package.json'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export { default as Repl } from './Repl.vue'
+export { default as Repl, type Props as ReplProps } from './Repl.vue'
 export { default as Preview } from './output/Preview.vue'
-export { default as Sandbox } from './output/Sandbox.vue'
+export { default as Sandbox, type SandboxProps } from './output/Sandbox.vue'
+export type { OutputModes } from './types'
 export * from './core'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,4 @@
 export { default as Repl } from './Repl.vue'
 export { default as Preview } from './output/Preview.vue'
 export { default as Sandbox } from './output/Sandbox.vue'
-export type { SandboxProps } from './output/Sandbox.vue'
-export {
-  useStore,
-  File,
-  type SFCOptions,
-  type StoreState,
-  type Store,
-  type ReplStore,
-} from './store'
-export { useVueImportMap, mergeImportMap, type ImportMap } from './import-map'
-export { compileFile } from './transform'
-export type { Props as ReplProps } from './Repl.vue'
-export type { OutputModes } from './types'
-export { version as languageToolsVersion } from '@vue/language-service/package.json'
+export * from './core'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,7 @@ export default mergeConfig(base, {
     lib: {
       entry: {
         'vue-repl': './src/index.ts',
+        transform: './src/transform.ts',
         'monaco-editor': './src/editor/MonacoEditor.vue',
         'codemirror-editor': './src/editor/CodeMirrorEditor.vue',
       },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,7 @@ export default mergeConfig(base, {
     lib: {
       entry: {
         'vue-repl': './src/index.ts',
+        store: './src/store.ts',
         transform: './src/transform.ts',
         'monaco-editor': './src/editor/MonacoEditor.vue',
         'codemirror-editor': './src/editor/CodeMirrorEditor.vue',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,8 +57,7 @@ export default mergeConfig(base, {
     lib: {
       entry: {
         'vue-repl': './src/index.ts',
-        store: './src/store.ts',
-        transform: './src/transform.ts',
+        core: './src/core.ts',
         'monaco-editor': './src/editor/MonacoEditor.vue',
         'codemirror-editor': './src/editor/CodeMirrorEditor.vue',
       },


### PR DESCRIPTION
add new entries to import `compileFile`

resolve #304

edit: realised that we couldve import more utilities besides `compileFile`, thats why i created a new export entry `core.ts`. The name might be not appropriated though