### PR TITLE
fix(store): to check ImportMap after deserialize

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -272,7 +272,10 @@ export function useStore(
     if (vueVersion.value) files._version = vueVersion.value
     return '#' + utoa(JSON.stringify(files))
   }
-  const deserialize: ReplStore['deserialize'] = (serializedState: string) => {
+  const deserialize: ReplStore['deserialize'] = (
+    serializedState: string,
+    checkBuiltinImportMap = true,
+  ) => {
     if (serializedState.startsWith('#'))
       serializedState = serializedState.slice(1)
     let saved: any
@@ -289,6 +292,9 @@ export function useStore(
       } else {
         setFile(files.value, filename, saved[filename])
       }
+    }
+    if (checkBuiltinImportMap) {
+      applyBuiltinImportMap()
     }
   }
   const getFiles: ReplStore['getFiles'] = () => {
@@ -333,7 +339,7 @@ export function useStore(
   }
 
   if (serializedState) {
-    deserialize(serializedState)
+    deserialize(serializedState, false)
   } else {
     setDefaultFile()
   }
@@ -444,7 +450,12 @@ export interface ReplStore extends UnwrapRef<StoreState> {
   setImportMap(map: ImportMap, merge?: boolean): void
   getTsConfig(): Record<string, any>
   serialize(): string
-  deserialize(serializedState: string): void
+  /**
+   * Deserializes the given string to restore the REPL store state.
+   * @param serializedState - The serialized state string.
+   * @param checkBuiltinImportMap - Whether to check the built-in import map. Default to true
+   */
+  deserialize(serializedState: string, checkBuiltinImportMap?: boolean): void
   getFiles(): Record<string, string>
   setFiles(newFiles: Record<string, string>, mainFile?: string): Promise<void>
 }


### PR DESCRIPTION
Need to check ImportMap after deserialize because `builtinImportMap` data will be deleted during `store.serialize`.

```ts
 /**
  * Deserializes the given string to restore the REPL store state.
  * @param serializedState - The serialized state string.
  * @param checkBuiltinImportMap - Whether to check the built-in import map. Default to true
  */
deserialize(serializedState: string, checkBuiltinImportMap?: boolean): void
```