### PR TITLE
feat: all cdn resources can be replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,73 @@ const store = useStore(
   <Sandbox :store="store" />
 </template>
 ```
+
+<details>
+<summary>Configuration options for resource links. (replace CDN resources)</summary>
+
+```ts
+export type ResourceLinkConfigs = {
+  /** URL for ES Module Shims. */
+  esModuleShims?: string
+  /** Function that generates the Vue compiler URL based on the version. */
+  vueCompilerUrl?: (version: string) => string
+  /** Function that generates the TypeScript library URL based on the version. */
+  typescriptLib?: (version: string) => string
+
+  /** [monaco] Function that generates a URL to fetch the latest version of a package. */
+  pkgLatestVersionUrl?: (pkgName: string) => string
+  /** [monaco] Function that generates a URL to browse a package directory. */
+  pkgDirUrl?: (pkgName: string, pkgVersion: string, pkgPath: string) => string
+  /** [monaco] Function that generates a URL to fetch the content of a file from a package. */
+  pkgFileTextUrl?: (
+    pkgName: string,
+    pkgVersion: string | undefined,
+    pkgPath: string,
+  ) => string
+}
+```
+
+**unpkg**
+
+```ts
+const store = useStore({
+  resourceLinks: ref({
+    esModuleShims:
+      'https://unpkg.com/es-module-shims@1.5.18/dist/es-module-shims.wasm.js',
+    vueCompilerUrl: (version) =>
+      `https://unpkg.com/@vue/compiler-sfc@${version}/dist/compiler-sfc.esm-browser.js`,
+    typescriptLib: (version) =>
+      `https://unpkg.com/typescript@${version}/lib/typescript.js`,
+    pkgLatestVersionUrl: (pkgName) =>
+      `https://unpkg.com/${pkgName}@latest/package.json`,
+    pkgDirUrl: (pkgName, pkgVersion, pkgPath) =>
+      `https://unpkg.com/${pkgName}@${pkgVersion}/${pkgPath}/?meta`,
+    pkgFileTextUrl: (pkgName, pkgVersion, pkgPath) =>
+      `https://unpkg.com/${pkgName}@${pkgVersion || 'latest'}/${pkgPath}`,
+  }),
+})
+```
+
+**npmmirror**
+
+```ts
+const store = useStore({
+  resourceLinks: ref({
+    esModuleShims:
+      'https://registry.npmmirror.com/es-module-shims/1.5.18/files/dist/es-module-shims.wasm.js',
+    vueCompilerUrl: (version) =>
+      `https://registry.npmmirror.com/@vue/compiler-sfc/${version}/files/dist/compiler-sfc.esm-browser.js`,
+    typescriptLib: (version) =>
+      `https://registry.npmmirror.com/typescript/${version}/files/lib/typescript.js`,
+
+    pkgLatestVersionUrl: (pkgName) =>
+      `https://registry.npmmirror.com/${pkgName}/latest/files/package.json`,
+    pkgDirUrl: (pkgName, pkgVersion, pkgPath) =>
+      `https://registry.npmmirror.com/${pkgName}/${pkgVersion}/files/${pkgPath}/?meta`,
+    pkgFileTextUrl: (pkgName, pkgVersion, pkgPath) =>
+      `https://registry.npmmirror.com/${pkgName}/${pkgVersion || 'latest'}/files/${pkgPath}`,
+  }),
+})
+```
+
+</details>

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@types/node": "^24.2.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "@volar/jsdelivr": "2.4.23",
+    "@volar/language-service": "~2.4.11",
     "@volar/monaco": "2.4.23",
     "@volar/typescript": "2.4.23",
     "@vue/babel-plugin-jsx": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@volar/jsdelivr':
         specifier: 2.4.23
         version: 2.4.23
+      '@volar/language-service':
+        specifier: ~2.4.11
+        version: 2.4.23
       '@volar/monaco':
         specifier: 2.4.23
         version: 2.4.23
@@ -240,8 +243,8 @@ packages:
   '@emmetio/css-abbreviation@2.1.8':
     resolution: {integrity: sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==}
 
-  '@emmetio/css-parser@https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660':
-    resolution: {tarball: https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660}
+  '@emmetio/css-parser@git+https://git@github.com:ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660':
+    resolution: {commit: 370c480ac103bd17c7bcfb34bf5d577dc40d3660, repo: git@github.com:ramya-rao-a/css-parser.git, type: git}
     version: 0.4.0
 
   '@emmetio/html-matcher@1.3.0':
@@ -586,56 +589,67 @@ packages:
     resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
@@ -2645,7 +2659,7 @@ snapshots:
     dependencies:
       '@emmetio/scanner': 1.0.4
 
-  '@emmetio/css-parser@https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660':
+  '@emmetio/css-parser@git+https://git@github.com:ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660':
     dependencies:
       '@emmetio/stream-reader': 2.2.0
       '@emmetio/stream-reader-utils': 0.1.0
@@ -4898,7 +4912,7 @@ snapshots:
 
   volar-service-emmet@0.0.65(@volar/language-service@2.4.23):
     dependencies:
-      '@emmetio/css-parser': https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660
+      '@emmetio/css-parser': git+https://git@github.com:ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660
       '@emmetio/html-matcher': 1.3.0
       '@vscode/emmet-helper': 2.11.0
       vscode-uri: 3.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,8 +243,8 @@ packages:
   '@emmetio/css-abbreviation@2.1.8':
     resolution: {integrity: sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==}
 
-  '@emmetio/css-parser@git+https://git@github.com:ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660':
-    resolution: {commit: 370c480ac103bd17c7bcfb34bf5d577dc40d3660, repo: git@github.com:ramya-rao-a/css-parser.git, type: git}
+  '@emmetio/css-parser@https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660':
+    resolution: {tarball: https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660}
     version: 0.4.0
 
   '@emmetio/html-matcher@1.3.0':
@@ -589,67 +589,56 @@ packages:
     resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
@@ -2659,7 +2648,7 @@ snapshots:
     dependencies:
       '@emmetio/scanner': 1.0.4
 
-  '@emmetio/css-parser@git+https://git@github.com:ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660':
+  '@emmetio/css-parser@https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660':
     dependencies:
       '@emmetio/stream-reader': 2.2.0
       '@emmetio/stream-reader-utils': 0.1.0
@@ -4912,7 +4901,7 @@ snapshots:
 
   volar-service-emmet@0.0.65(@volar/language-service@2.4.23):
     dependencies:
-      '@emmetio/css-parser': git+https://git@github.com:ramya-rao-a/css-parser.git#370c480ac103bd17c7bcfb34bf5d577dc40d3660
+      '@emmetio/css-parser': https://codeload.github.com/ramya-rao-a/css-parser/tar.gz/370c480ac103bd17c7bcfb34bf5d577dc40d3660
       '@emmetio/html-matcher': 1.3.0
       '@vscode/emmet-helper': 2.11.0
       vscode-uri: 3.1.0

--- a/src/monaco/env.ts
+++ b/src/monaco/env.ts
@@ -122,6 +122,10 @@ export interface WorkerMessage {
   event: 'init'
   tsVersion: string
   tsLocale?: string
+  pkgDirUrl?: string
+  pkgFileTextUrl?: string
+  pkgLatestVersionUrl?: string
+  typescriptLib?: string
 }
 
 export function loadMonacoEnv(store: Store) {
@@ -135,11 +139,27 @@ export function loadMonacoEnv(store: Store) {
               resolve()
             }
           })
-          worker.postMessage({
+
+          const {
+            pkgDirUrl,
+            pkgFileTextUrl,
+            pkgLatestVersionUrl,
+            typescriptLib,
+          } = store.resourceLinks || {}
+
+          const message: WorkerMessage = {
             event: 'init',
             tsVersion: store.typescriptVersion,
             tsLocale: store.locale,
-          } satisfies WorkerMessage)
+            pkgDirUrl: pkgDirUrl ? String(pkgDirUrl) : undefined,
+            pkgFileTextUrl: pkgFileTextUrl ? String(pkgFileTextUrl) : undefined,
+            pkgLatestVersionUrl: pkgLatestVersionUrl
+              ? String(pkgLatestVersionUrl)
+              : undefined,
+            typescriptLib: typescriptLib ? String(typescriptLib) : undefined,
+          }
+
+          worker.postMessage(message)
         })
         await init
         return worker

--- a/src/monaco/resource.ts
+++ b/src/monaco/resource.ts
@@ -16,7 +16,6 @@ export type CreateNpmFileSystemOptions = {
     pkgPath: string,
   ) => string
   getPackageFileTextUrl?: (
-    path: string,
     pkgName: string,
     pkgVersion: string | undefined,
     pkgPath: string,
@@ -24,14 +23,12 @@ export type CreateNpmFileSystemOptions = {
 }
 
 const defaultUnpkgOptions: Required<CreateNpmFileSystemOptions> = {
-  getPackageLatestVersionUrl: (pkgName: string) =>
+  getPackageLatestVersionUrl: (pkgName) =>
     `https://unpkg.com/${pkgName}@latest/package.json`,
-  getPackageDirectoryUrl: (
-    pkgName: string,
-    pkgVersion: string,
-    pkgPath: string,
-  ) => `https://unpkg.com/${pkgName}@${pkgVersion}/${pkgPath}/?meta`,
-  getPackageFileTextUrl: (path: string) => `https://unpkg.com/${path}`,
+  getPackageDirectoryUrl: (pkgName, pkgVersion, pkgPath) =>
+    `https://unpkg.com/${pkgName}@${pkgVersion}/${pkgPath}/?meta`,
+  getPackageFileTextUrl: (pkgName, pkgVersion, pkgPath) =>
+    `https://unpkg.com/${pkgName}@${pkgVersion || 'latest'}/${pkgPath}`,
 }
 
 export function createNpmFileSystem(
@@ -235,7 +232,7 @@ export function createNpmFileSystem(
             return
           }
           const text = await fetchText(
-            getPackageFileTextUrl(path, pkgName, _version, pkgFilePath),
+            getPackageFileTextUrl(pkgName, _version, pkgFilePath),
           )
           if (text !== undefined) {
             onFetch?.(path, text)
@@ -317,7 +314,7 @@ export function createNpmFileSystem(
       version = modName.substring(modName.lastIndexOf('@') + 1)
     }
     if (!version && getPackageVersion) {
-      getPackageVersion?.(pkgName)
+      version = getPackageVersion?.(pkgName)
     }
     return [modName, pkgName, version, path]
   }

--- a/src/monaco/resource.ts
+++ b/src/monaco/resource.ts
@@ -1,0 +1,318 @@
+/**
+ * base on @volar/jsdelivr
+ * MIT License https://github.com/volarjs/volar.js/blob/master/packages/jsdelivr/LICENSE
+ */
+import type { FileSystem, FileType } from '@volar/language-service'
+import type { URI } from 'vscode-uri'
+
+const textCache = new Map<string, Promise<string | undefined>>()
+const jsonCache = new Map<string, Promise<any>>()
+
+export function createNpmFileSystem(
+  getCdnPath = (uri: URI): string | undefined => {
+    if (uri.path === '/node_modules') {
+      return ''
+    } else if (uri.path.startsWith('/node_modules/')) {
+      return uri.path.slice('/node_modules/'.length)
+    }
+  },
+  getPackageVersion?: (pkgName: string) => string | undefined,
+  onFetch?: (path: string, content: string) => void,
+): FileSystem {
+  const fetchResults = new Map<string, Promise<string | undefined>>()
+  const flatResults = new Map<
+    string,
+    Promise<
+      {
+        name: string
+        size: number
+        time: string
+        hash: string
+      }[]
+    >
+  >()
+
+  return {
+    async stat(uri) {
+      const path = getCdnPath(uri)
+      if (path === undefined) {
+        return
+      }
+      if (path === '') {
+        return {
+          type: 2 satisfies FileType.Directory,
+          size: -1,
+          ctime: -1,
+          mtime: -1,
+        }
+      }
+      return await _stat(path)
+    },
+    async readFile(uri) {
+      const path = getCdnPath(uri)
+      if (path === undefined) {
+        return
+      }
+      return await _readFile(path)
+    },
+    readDirectory(uri) {
+      const path = getCdnPath(uri)
+      if (path === undefined) {
+        return []
+      }
+      return _readDirectory(path)
+    },
+  }
+
+  async function _stat(path: string) {
+    const [modName, pkgName, pkgVersion, pkgFilePath] = resolvePackageName(path)
+    if (!pkgName) {
+      if (modName.startsWith('@')) {
+        return {
+          type: 2 satisfies FileType.Directory,
+          ctime: -1,
+          mtime: -1,
+          size: -1,
+        }
+      } else {
+        return
+      }
+    }
+    if (!(await isValidPackageName(pkgName))) {
+      return
+    }
+
+    if (!pkgFilePath) {
+      // perf: skip flat request
+      return {
+        type: 2 satisfies FileType.Directory,
+        ctime: -1,
+        mtime: -1,
+        size: -1,
+      }
+    }
+
+    if (!flatResults.has(modName)) {
+      flatResults.set(modName, flat(pkgName, pkgVersion))
+    }
+
+    const flatResult = await flatResults.get(modName)!
+    const filePath = path.slice(modName.length)
+    const file = flatResult.find((file) => file.name === filePath)
+    if (file) {
+      return {
+        type: 1 satisfies FileType.File,
+        ctime: new Date(file.time).valueOf(),
+        mtime: new Date(file.time).valueOf(),
+        size: file.size,
+      }
+    } else if (
+      flatResult.some((file) => file.name.startsWith(filePath + '/'))
+    ) {
+      return {
+        type: 2 satisfies FileType.Directory,
+        ctime: -1,
+        mtime: -1,
+        size: -1,
+      }
+    }
+  }
+
+  async function _readDirectory(path: string): Promise<[string, FileType][]> {
+    const [modName, pkgName, pkgVersion] = resolvePackageName(path)
+    if (!pkgName || !(await isValidPackageName(pkgName))) {
+      return []
+    }
+
+    if (!flatResults.has(modName)) {
+      flatResults.set(modName, flat(pkgName, pkgVersion))
+    }
+
+    const flatResult = await flatResults.get(modName)!
+    const dirPath = path.slice(modName.length)
+    const files = flatResult
+      .filter((f) => f.name.substring(0, f.name.lastIndexOf('/')) === dirPath)
+      .map((f) => f.name.slice(dirPath.length + 1))
+    const dirs = flatResult
+      .filter(
+        (f) =>
+          f.name.startsWith(dirPath + '/') &&
+          f.name.substring(dirPath.length + 1).split('/').length >= 2,
+      )
+      .map((f) => f.name.slice(dirPath.length + 1).split('/')[0])
+
+    return [
+      ...files.map<[string, FileType]>((f) => [f, 1 satisfies FileType.File]),
+      ...[...new Set(dirs)].map<[string, FileType]>((f) => [
+        f,
+        2 satisfies FileType.Directory,
+      ]),
+    ]
+  }
+
+  async function _readFile(path: string): Promise<string | undefined> {
+    const [_modName, pkgName, _version, pkgFilePath] = resolvePackageName(path)
+    if (!pkgName || !pkgFilePath || !(await isValidPackageName(pkgName))) {
+      return
+    }
+
+    if (!fetchResults.has(path)) {
+      fetchResults.set(
+        path,
+        (async () => {
+          if ((await _stat(path))?.type !== (1 satisfies FileType.File)) {
+            return
+          }
+          const text = await fetchText(`https://cdn.jsdelivr.net/npm/${path}`)
+          if (text !== undefined) {
+            onFetch?.(path, text)
+          }
+          return text
+        })(),
+      )
+    }
+
+    return await fetchResults.get(path)!
+  }
+
+  async function flat(pkgName: string, version: string | undefined) {
+    version ??= 'latest'
+
+    // resolve latest tag
+    if (version === 'latest') {
+      const data = await fetchJson<{ version: string | null }>(
+        `https://data.jsdelivr.com/v1/package/resolve/npm/${pkgName}@${version}`,
+      )
+      if (!data?.version) {
+        return []
+      }
+      version = data.version
+    }
+
+    const flat = await fetchJson<{
+      files: {
+        name: string
+        size: number
+        time: string
+        hash: string
+      }[]
+    }>(`https://data.jsdelivr.com/v1/package/npm/${pkgName}@${version}/flat`)
+    if (!flat) {
+      return []
+    }
+
+    return flat.files
+  }
+
+  async function isValidPackageName(pkgName: string) {
+    // ignore @aaa/node_modules
+    if (pkgName.endsWith('/node_modules')) {
+      return false
+    }
+    // hard code to skip known invalid package
+    if (
+      pkgName.endsWith('.d.ts') ||
+      pkgName.startsWith('@typescript/') ||
+      pkgName.startsWith('@types/typescript__')
+    ) {
+      return false
+    }
+    // don't check @types if original package already having types
+    if (pkgName.startsWith('@types/')) {
+      let originalPkgName = pkgName.slice('@types/'.length)
+      if (originalPkgName.indexOf('__') >= 0) {
+        originalPkgName = '@' + originalPkgName.replace('__', '/')
+      }
+      const packageJson = await _readFile(`${originalPkgName}/package.json`)
+      if (!packageJson) {
+        return false
+      }
+      const packageJsonObj = JSON.parse(packageJson)
+      if (packageJsonObj.types || packageJsonObj.typings) {
+        return false
+      }
+      const indexDts = await _stat(`${originalPkgName}/index.d.ts`)
+      if (indexDts?.type === (1 satisfies FileType.File)) {
+        return false
+      }
+    }
+    return true
+  }
+
+  /**
+   * @example
+   * "a/b/c" -> ["a", "a", undefined, "b/c"]
+   * "@a" -> ["@a", undefined, undefined, ""]
+   * "@a/b/c" -> ["@a/b", "@a/b", undefined, "c"]
+   * "@a/b@1.2.3/c" -> ["@a/b@1.2.3", "@a/b", "1.2.3", "c"]
+   */
+  function resolvePackageName(
+    input: string,
+  ): [
+    modName: string,
+    pkgName: string | undefined,
+    version: string | undefined,
+    path: string,
+  ] {
+    const parts = input.split('/')
+    let modName = parts[0]
+    let path: string
+    if (modName.startsWith('@')) {
+      if (!parts[1]) {
+        return [modName, undefined, undefined, '']
+      }
+      modName += '/' + parts[1]
+      path = parts.slice(2).join('/')
+    } else {
+      path = parts.slice(1).join('/')
+    }
+    let pkgName = modName
+    let version: string | undefined
+    if (modName.lastIndexOf('@') >= 1) {
+      pkgName = modName.substring(0, modName.lastIndexOf('@'))
+      version = modName.substring(modName.lastIndexOf('@') + 1)
+    }
+    if (!version && getPackageVersion) {
+      getPackageVersion?.(pkgName)
+    }
+    return [modName, pkgName, version, path]
+  }
+}
+
+async function fetchText(url: string) {
+  if (!textCache.has(url)) {
+    textCache.set(
+      url,
+      (async () => {
+        try {
+          const res = await fetch(url)
+          if (res.status === 200) {
+            return await res.text()
+          }
+        } catch {
+          // ignore
+        }
+      })(),
+    )
+  }
+  return await textCache.get(url)!
+}
+
+async function fetchJson<T>(url: string) {
+  if (!jsonCache.has(url)) {
+    jsonCache.set(
+      url,
+      (async () => {
+        try {
+          const res = await fetch(url)
+          if (res.status === 200) {
+            return await res.json()
+          }
+        } catch {
+          // ignore
+        }
+      })(),
+    )
+  }
+  return (await jsonCache.get(url)!) as T
+}

--- a/src/monaco/vue.worker.ts
+++ b/src/monaco/vue.worker.ts
@@ -3,7 +3,6 @@ import {
   createTypeScriptWorkerLanguageService,
   Language,
 } from '@volar/monaco/worker'
-import { createNpmFileSystem } from './resource'
 import {
   type VueCompilerOptions,
   VueVirtualCode,
@@ -33,6 +32,8 @@ import { getComponentSlots } from '@vue/typescript-plugin/lib/requests/getCompon
 import { getElementAttrs } from '@vue/typescript-plugin/lib/requests/getElementAttrs'
 import { getElementNames } from '@vue/typescript-plugin/lib/requests/getElementNames'
 import { getPropertiesAtLocation } from '@vue/typescript-plugin/lib/requests/getPropertiesAtLocation'
+
+import { createNpmFileSystem } from './resource'
 
 export interface CreateData {
   tsconfig: {

--- a/src/monaco/vue.worker.ts
+++ b/src/monaco/vue.worker.ts
@@ -1,9 +1,9 @@
-import { createNpmFileSystem } from '@volar/jsdelivr'
 import {
   type LanguageServiceEnvironment,
   createTypeScriptWorkerLanguageService,
   Language,
 } from '@volar/monaco/worker'
+import { createNpmFileSystem } from './resource'
 import {
   type VueCompilerOptions,
   VueVirtualCode,

--- a/src/output/Sandbox.vue
+++ b/src/output/Sandbox.vue
@@ -129,6 +129,11 @@ function createSandbox() {
       /<!--PREVIEW-OPTIONS-PLACEHOLDER-HTML-->/,
       previewOptions.value?.placeholderHTML || '',
     )
+    .replace(
+      /<!--ES-MODULE-SHIMS-LINK-->/,
+      store.value.resourceLinks?.esModuleShims ||
+        'https://cdn.jsdelivr.net/npm/es-module-shims@1.5.18/dist/es-module-shims.wasm.js',
+    )
   sandbox.srcdoc = sandboxSrc
   containerRef.value?.appendChild(sandbox)
 

--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -6,8 +6,9 @@
         color-scheme: dark;
       }
       body {
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-          Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
+          Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
       }
     </style>
     <!-- PREVIEW-OPTIONS-HEAD-HTML -->
@@ -366,10 +367,7 @@
     </script>
 
     <!-- ES Module Shims: Import maps polyfill for modules browsers without import maps support (all except Chrome 89+) -->
-    <script
-      async
-      src="https://cdn.jsdelivr.net/npm/es-module-shims@1.5.18/dist/es-module-shims.wasm.js"
-    ></script>
+    <script async src="<!--ES-MODULE-SHIMS-LINK-->"></script>
     <script type="importmap">
       <!--IMPORT_MAP-->
     </script>


### PR DESCRIPTION
- refactor(deps): @volar/jsdelivr -> local
- feat(monaco): allow resources to be requested on demand without relying on jsdelivr-flat
  - https://data.jsdelivr.com/v1/package/npm/vue@3.5.13/flat
  - https://unpkg.com/vue@3.5.13/dist/?meta
  - https://registry.npmmirror.com/vue/3.5.13/files/dist/?meta
- feat(store): `resourceLinks` to custom cdn


```ts
const store = useStore({
  resourceLinks: ref({
      esModuleShims: 'https://registry.npmmirror.com/es-module-shims/1.5.18/files/dist/es-module-shims.wasm.js',
      pkgLatestVersionUrl: (pkgName: string) => `https://registry.npmmirror.com/${pkgName}/latest/files/package.json`,
      pkgDirUrl: (pkgName: string, pkgVersion: string, pkgPath: string) => `https://registry.npmmirror.com/${pkgName}/${pkgVersion}/files/${pkgPath}/?meta`,
      pkgFileTextUrl: (pkgName: string, pkgVersion: string | undefined, pkgPath: string) => `https://registry.npmmirror.com/${pkgName}/${pkgVersion || 'latest'}/files/${pkgPath}`,
      typescriptLib: (version) => `https://registry.npmmirror.com/typescript/${version}/files/lib/typescript.js`,
  }),
})
```

```ts
export type ResourceLinkConfigs = {
  esModuleShims?: string
  vueCompilerUrl?: (version: string) => string
  typescriptLib?: (version: string) => string

  // for monaco
  pkgLatestVersionUrl?: (pkgName: string) => string
  pkgDirUrl?: (pkgName: string, pkgVersion: string, pkgPath: string) => string
  pkgFileTextUrl?: (pkgName: string, pkgVersion: string | undefined, pkgPath: string) => string
}
```

close https://github.com/vuejs/repl/issues/280 https://github.com/vuejs/repl/issues/159