### PR TITLE
fix: only handle `./` prefix modules for ExportNamedDeclaration

### DIFF
--- a/src/output/moduleCompiler.ts
+++ b/src/output/moduleCompiler.ts
@@ -201,7 +201,7 @@ function processModule(store: Store, src: string, filename: string) {
           }
         }
         s.remove(node.start!, node.declaration.start!)
-      } else if (node.source) {
+      } else if (node.source && node.source.value.startsWith('./')) {
         // export { foo, bar } from './foo'
         const importId = defineImport(node, node.source.value)
         for (const spec of node.specifiers) {


### PR DESCRIPTION
```ts
// prevent handle the declaration:
export { shallowRef as useRef } from 'vue';
```