### PR TITLE
fix(module-compiler): support more exports

### DIFF
--- a/src/output/moduleCompiler.ts
+++ b/src/output/moduleCompiler.ts
@@ -203,12 +203,32 @@ function processModule(store: Store, src: string, filename: string) {
         s.remove(node.start!, node.declaration.start!)
       } else if (node.source) {
         // export { foo, bar } from './foo'
-        const importId = defineImport(node, node.source.value)
-        for (const spec of node.specifiers) {
-          defineExport(
-            (spec.exported as Identifier).name,
-            `${importId}.${(spec as ExportSpecifier).local.name}`,
-          )
+        // export * as foo from './foo'
+        if (node.source.value.startsWith('./')) {
+          const importId = defineImport(node, node.source.value)
+          for (const spec of node.specifiers) {
+            defineExport(
+              (spec.exported as Identifier).name,
+              spec.type === 'ExportNamespaceSpecifier'
+                ? importId
+                : `${importId}.${(spec as ExportSpecifier).local.name}`,
+            )
+          }
+        } else {
+          // export { foo, bar } from 'module'
+          // export * as foo from 'module'
+          // export { default as foo } from 'module'
+          for (const spec of node.specifiers) {
+            const localName = (spec as ExportSpecifier).local?.name
+            const exportName = (spec.exported as Identifier).name
+            const isSameName = localName === exportName
+            s.prepend(
+              spec.type === 'ExportNamespaceSpecifier'
+                ? `import * as ${exportName} from '${node.source.value}';\n`
+                : `import { ${isSameName ? exportName : localName + ' as ' + exportName} } from '${node.source.value}';\n`,
+            )
+            defineExport(exportName, exportName)
+          }
         }
         s.remove(node.start!, node.end!)
       } else {


### PR DESCRIPTION
from https://github.com/vuejs/repl/pull/327

Compile case:

[repl link](https://repl-vuejs.vercel.app/#eNqNU8uO0zAU/RXjTQdIE6UzElLJjAbQSMACECCx8cZNbtoUv2Q7pSjKv3Njt2noPDRSFvE959jnvjr6zph01wJd0sKVtjGeOPCtuWGqkUZbTzpioSY9qa2WZIbU2QTiCVnpRULW4BNS8b9blxChK+42oyLNOCqYKrVyWkDaqFpf3Neliks4il8eBZ5ItybXg4WL2UcQQpNf2orqxQwpRRYdo1c8eJBGcA94IqTY5DddF8R9X2R4CtFGmdaT3VzqCsQ1o4gzSjIEi2yipwn1Dp+vm3W6dVphcbpBz2ippWkE2K/GN2iP0SUJyIBxdPfnc4h520JyjJcbKH8/EN+6/RBj9JsFB3YHjI6Y5xZLE+G7H19gj/8jiO5bgewnwO+AtW4Hj5H2vlUV2p7wgttPoY+NWv90d3sPyh2TGowOzD7wGcW2f3gi9ZPdy/Qq6JjqsYpxTuaSm7M6RuD/S2Lr5xCijG68N26ZZWWlUIz9anY2VeAzZWQ2cm+v0vxNusiz1+DkJL0wU8+4KPBu8zTH7/JwySQBjgp0DfvDvFdQ81Z4wl2c2nHKw2n2lqlHqYtHua8GzmFrImNM75yFSzOu1Qq94WaND/LJyp1jYc9wsUfK6QXMcmCfsox7x3Hr8tPrMbgKQdr/AwBPZOA=)

```ts
export { default as dayjs } from 'dayjs';
export { default as dayjs2 } from 'dayjs';
export * as lodash from 'lodash-es';
export * as bo2 from './b.js'
export { a } from './b.js'
export { get, set } from 'lodash-es'
```

=> 

```ts
import { set } from 'lodash-es';
import { get } from 'lodash-es';
import * as lodash from 'lodash-es';
import { default as dayjs2 } from 'dayjs';
import { default as dayjs } from 'dayjs';
const __module__ = __modules__["src/a.js"] = { [Symbol.toStringTag]: "Module" }

const __import_1__ = __modules__["src/b.js"]

__export__(__module__, "dayjs", () => dayjs)
__export__(__module__, "dayjs2", () => dayjs2)
__export__(__module__, "lodash", () => lodash)
__export__(__module__, "bo2", () => __import_1__)
__export__(__module__, "a", () => __import_1__.a)
__export__(__module__, "get", () => get)
__export__(__module__, "set", () => set)
```