### PR TITLE
feat: show SSR output

### DIFF
--- a/src/Repl.vue
+++ b/src/Repl.vue
@@ -19,6 +19,7 @@ export interface Props {
   autoResize?: boolean
   showCompileOutput?: boolean
   showImportMap?: boolean
+  showSsrOutput?: boolean
   showTsConfig?: boolean
   clearConsole?: boolean
   layout?: 'horizontal' | 'vertical'
@@ -54,6 +55,7 @@ const props = withDefaults(defineProps<Props>(), {
   autoResize: true,
   showCompileOutput: true,
   showImportMap: true,
+  showSsrOutput: false,
   showTsConfig: true,
   clearConsole: true,
   layoutReverse: false,
@@ -105,6 +107,7 @@ defineExpose({ reload })
           ref="output"
           :editor-component="editor"
           :show-compile-output="props.showCompileOutput"
+          :show-ssr-output="props.showSsrOutput"
           :ssr="!!props.ssr"
         />
       </template>

--- a/src/output/SsrOutput.vue
+++ b/src/output/SsrOutput.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+defineProps<{
+  html: string
+  context: unknown
+}>()
+</script>
+
+<template>
+  <div class="ssr-output">
+    <strong>HTML</strong>
+    <pre class="ssr-output-pre">{{ html }}</pre>
+    <strong>Context</strong>
+    <pre class="ssr-output-pre">{{ context }}</pre>
+  </div>
+</template>
+
+<style scoped>
+.ssr-output {
+  background: var(--bg);
+  box-sizing: border-box;
+  color: var(--text-light);
+  height: 100%;
+  overflow: auto;
+  padding: 10px;
+  width: 100%;
+}
+
+.ssr-output-pre {
+  font-family: var(--font-code);
+  white-space: pre-wrap;
+}
+</style>

--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -35,7 +35,8 @@
           const send_message = (payload) =>
             parent.postMessage({ ...payload }, ev.origin)
           const send_reply = (payload) => send_message({ ...payload, cmd_id })
-          const send_ok = () => send_reply({ action: 'cmd_ok' })
+          const send_ok = (response) =>
+            send_reply({ action: 'cmd_ok', args: response })
           const send_error = (message, stack) =>
             send_reply({ action: 'cmd_error', message, stack })
 
@@ -65,7 +66,11 @@
                 scriptEls.push(scriptEl)
                 await done
               }
-              send_ok()
+              if (window.__ssr_promise__) {
+                send_ok(await window.__ssr_promise__)
+              } else {
+                send_ok()
+              }
             } catch (e) {
               send_error(e.message, e.stack)
             }

--- a/src/store.ts
+++ b/src/store.ts
@@ -368,6 +368,7 @@ export function useStore(
     showOutput,
     outputMode,
     sfcOptions,
+    ssrOutput: { html: '', context: '' },
     compiler,
     loading,
     vueVersion,
@@ -429,6 +430,10 @@ export type StoreState = ToRefs<{
   showOutput: boolean
   outputMode: OutputModes
   sfcOptions: SFCOptions
+  ssrOutput: {
+    html: string
+    context: unknown
+  }
   /** `@vue/compiler-sfc` */
   compiler: typeof defaultCompiler
   /* only apply for compiler-sfc */
@@ -474,6 +479,7 @@ export type Store = Pick<
   | 'showOutput'
   | 'outputMode'
   | 'sfcOptions'
+  | 'ssrOutput'
   | 'compiler'
   | 'vueVersion'
   | 'locale'

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface EditorEmits {
 }
 export type EditorComponentType = Component<EditorProps>
 
-export type OutputModes = 'preview' | EditorMode
+export type OutputModes = 'preview' | 'ssr output' | EditorMode
 
 export const injectKeyProps: InjectionKey<
   ToRefs<Required<Props & { autoSave: boolean }>>

--- a/test/main.ts
+++ b/test/main.ts
@@ -60,6 +60,7 @@ const App = {
         editor: MonacoEditor,
         // layout: 'vertical',
         ssr: true,
+        showSsrOutput: true,
         sfcOptions: {
           script: {
             // inlineTemplate: false


### PR DESCRIPTION
This adds an option to show the SSR output.

My goal was to make it a bit easier to investigate SSR hydration problems by showing the generated HTML directly in the UI.

The new option is disabled by default, but it is enabled in `test/main.ts`.

I've also exposed the SSR context object, which is populated if teleports or sync watchers are used.

![SSR Output](https://github.com/user-attachments/assets/38e31d30-b494-4a97-b0e6-06f1d6aed9fb)
