### PR TITLE
fix: handle Vue 3.6+ vapor runtime imports correctly

### DIFF
--- a/src/import-map.ts
+++ b/src/import-map.ts
@@ -1,5 +1,15 @@
 import { computed, version as currentVersion, ref } from 'vue'
 
+export function getVersions(version: string): number[] {
+  return version.split('.').map((v) => parseInt(v, 10))
+}
+
+export function isVaporSupported(version: string): boolean{
+  const [major, minor] = getVersions(version)
+  // vapor mode is supported in v3.6+
+  return major > 3 || (major === 3 && minor >= 6)
+}
+
 export function useVueImportMap(
   defaults: {
     runtimeDev?: string | (() => string)
@@ -18,10 +28,7 @@ export function useVueImportMap(
 
   function getVueURL() {
     const version = vueVersion.value || currentVersion
-    const [major, minor] = version.split('.').map(Number)
-    const isVaporSupported = major > 3 || (major === 3 && minor >= 6)
-
-    return isVaporSupported
+    return isVaporSupported(version)
       ? `https://cdn.jsdelivr.net/npm/vue@${version}/dist/vue.runtime-with-vapor.esm-browser${productionMode.value ? `.prod` : ``}.js`
       : `https://cdn.jsdelivr.net/npm/@vue/runtime-dom@${version}/dist/runtime-dom.esm-browser${productionMode.value ? `.prod` : ``}.js`
   }

--- a/src/import-map.ts
+++ b/src/import-map.ts
@@ -15,15 +15,24 @@ export function useVueImportMap(
 
   const productionMode = ref(false)
   const vueVersion = ref<string | null>(defaults.vueVersion || null)
+
+  function getVueURL() {
+    const version = vueVersion.value || currentVersion
+    const [major, minor] = version.split('.').map(Number)
+    const isVaporSupported = major > 3 || (major === 3 && minor >= 6)
+
+    return isVaporSupported
+      ? `https://cdn.jsdelivr.net/npm/vue@${version}/dist/vue.runtime-with-vapor.esm-browser${productionMode.value ? `.prod` : ``}.js`
+      : `https://cdn.jsdelivr.net/npm/@vue/runtime-dom@${version}/dist/runtime-dom.esm-browser${productionMode.value ? `.prod` : ``}.js`
+  }
+
   const importMap = computed<ImportMap>(() => {
     const vue =
       (!vueVersion.value &&
         normalizeDefaults(
           productionMode.value ? defaults.runtimeProd : defaults.runtimeDev,
         )) ||
-      `https://cdn.jsdelivr.net/npm/@vue/runtime-dom@${
-        vueVersion.value || currentVersion
-      }/dist/runtime-dom.esm-browser${productionMode.value ? `.prod` : ``}.js`
+      getVueURL()
 
     const serverRenderer =
       (!vueVersion.value && normalizeDefaults(defaults.serverRenderer)) ||


### PR DESCRIPTION
close #356

### Summary
- Use `https://cdn.jsdelivr.net/npm/vue@3.6.x/dist/vue.runtime-with-vapor.esm-browser.js` as the runtime import.
- Use `createVaporApp` or `createVaporSSRApp` when vapor mode is supported and `App.vue` is a vapor component.