### PR TITLE
fix: Sandbox iframe overflow-y

### DIFF
--- a/src/output/Sandbox.vue
+++ b/src/output/Sandbox.vue
@@ -369,6 +369,9 @@ defineExpose({ reload, container: containerRef })
   border: none;
   background-color: #fff;
 }
+.iframe-container :deep(iframe) {
+  display: block;
+}
 .iframe-container.dark :deep(iframe) {
   background-color: #1e1e1e;
 }


### PR DESCRIPTION
The HTML iframe element has display: inline by default, which can lead to scrollbar overflow-y.
This issue occurred when using a Header element and a Sandbox element while playing with the feature. (see example screenshot)

A simple display: block will resolve this issue.

<img width="252" height="245" alt="image" src="https://github.com/user-attachments/assets/3e32e1fd-76a8-4572-ae75-9fab177f9b53" />