### PR TITLE
Update dark mode styles in srcdoc.html

### DIFF
--- a/src/output/srcdoc.html
+++ b/src/output/srcdoc.html
@@ -2,8 +2,10 @@
 <html>
   <head>
     <style>
-      html.dark {
+      :root.dark {
         color-scheme: dark;
+        background-color: #000;
+        color: #fff;
       }
       body {
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,


### PR DESCRIPTION
The color-scheme CSS property changes only:

- The color of the canvas surface.
- The default colors of scrollbars and other interaction UI.
- The default colors of form controls.
- The default colors of other browser-provided UI, such as "spellcheck" underlines.