### PR TITLE
fix(store): restore default tsconfig in setFiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "build-preview": "vite build -c vite.preview.config.ts",
     "format": "prettier --write .",
     "lint": "eslint .",
+    "test": "node --test test/*.test.mjs",
     "typecheck": "vue-tsc --noEmit",
     "release": "bumpp --all",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",

--- a/src/store.ts
+++ b/src/store.ts
@@ -64,6 +64,15 @@ export function useStore(
     setImportMap(importMap)
   }
 
+  function applyDefaultTsConfig(targetFiles: Record<string, File>) {
+    if (!targetFiles[tsconfigFile]) {
+      targetFiles[tsconfigFile] = new File(
+        tsconfigFile,
+        JSON.stringify(tsconfig, undefined, 2),
+      )
+    }
+  }
+
   function init() {
     watchEffect(() => {
       compileFile(store, activeFile.value).then((errs) => (errors.value = errs))
@@ -142,12 +151,7 @@ export function useStore(
     )
 
     // init tsconfig
-    if (!files.value[tsconfigFile]) {
-      files.value[tsconfigFile] = new File(
-        tsconfigFile,
-        JSON.stringify(tsconfig, undefined, 2),
-      )
-    }
+    applyDefaultTsConfig(files.value)
 
     // compile rest of the files
     errors.value = []
@@ -339,6 +343,7 @@ export function useStore(
     for (const [filename, file] of Object.entries(newFiles)) {
       setFile(files, filename, file)
     }
+    applyDefaultTsConfig(files)
 
     const errors = []
     for (const file of Object.values(files)) {

--- a/test/store.test.mjs
+++ b/test/store.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import { after, test } from 'node:test'
+import { ref } from 'vue'
+import { createServer } from 'vite'
+
+const vite = await createServer({
+  appType: 'custom',
+  logLevel: 'silent',
+  server: { middlewareMode: true },
+})
+after(() => vite.close())
+
+const { tsconfigFile, useStore } = await vite.ssrLoadModule('/src/store.ts')
+
+function createStore() {
+  return useStore({ builtinImportMap: ref({ imports: {} }) })
+}
+
+test('setFiles applies the default tsconfig when none is provided', async () => {
+  const store = createStore()
+  store.init()
+  const defaultTsConfig = store.files[tsconfigFile].code
+
+  await store.setFiles({
+    'src/App.vue': '<template><div /></template>',
+  })
+
+  assert.equal(store.files[tsconfigFile].code, defaultTsConfig)
+})
+
+test('setFiles keeps a provided tsconfig', async () => {
+  const store = createStore()
+  const customTsConfig = JSON.stringify({ compilerOptions: { strict: true } })
+
+  await store.setFiles({
+    'src/App.vue': '<template><div /></template>',
+    [tsconfigFile]: customTsConfig,
+  })
+
+  assert.equal(store.files[tsconfigFile].code, customTsConfig)
+})


### PR DESCRIPTION
## What changed

- Restore the default `tsconfig.json` whenever `setFiles()` receives no tsconfig.
- Reuse the same defaulting path during store initialization and file replacement.
- Keep an explicitly provided `tsconfig.json` unchanged.
- Add focused Node test-runner coverage through Vite's SSR module loader, without adding a dependency.

## Why

`setFiles()` replaces the store's entire file record. Store initialization adds a default `tsconfig.json`, but the replacement path did not restore that default, so language tooling lost its configuration after callers replaced only their source files.

Fixes #383.

## How tested

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec prettier --check src/store.ts test/store.test.mjs package.json`
- `pnpm build` (passes; retains the existing API Extractor warning about its bundled TypeScript version)
- Vercel preview is unavailable for this fork because the check requires Vue organization deployment authorization; the local production build passes.

## Risk and rollout

- Risk: Low. The only new runtime behavior is adding the existing default tsconfig when `setFiles()` omits it; caller-provided tsconfig content still wins.
- Rollback: Revert this commit to restore the previous replacement behavior.

## Notes for reviewers

- Duplicate search covered open, closed, and merged PRs; open and closed issues; issue comments and linked PRs; commit history; remote branches; `src/store.ts`; and behavior/API terms.
- Search terms included `383`, `setFiles tsconfig`, `tsconfig.json`, `src/store.ts setFiles`, and `Using setFiles removes tsconfig.json`.
- No PR or upstream branch covers #383. The broad `tsconfig.json` search only found unrelated PRs #251 (dependency updates) and #28 (TypeScript import modifiers).
- Historical `setFiles` commits `177f675` and `424e00d` predate the tsconfig feature; PR #114 added tsconfig support but did not restore it after `setFiles()`.